### PR TITLE
Update webexploits.conf

### DIFF
--- a/webexploits.conf
+++ b/webexploits.conf
@@ -7,1230 +7,1240 @@
 
 [Definition]
 
-failregex = ^<HOST> -.*(GET|POST|HEAD).*(/\.git/config)
-            ^<HOST> -.*(GET|POST|HEAD).*(/api/jsonws/invoke)
-            ^<HOST> -.*(GET|POST|HEAD).*(/?a=fetch&content=<php>die(@md5(HelloThinkCMF))</php>)
-            ^<HOST> -.*(GET|POST|HEAD).*(/?XDEBUG_SESSION_START=phpstorm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mifs/.;/services/LogService)
-            ^<HOST> -.*(GET|POST|HEAD).*(/solr/admin/info/system?wt=json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ws/v1/cluster/apps/new-application)
-            ^<HOST> -.*(GET|POST|HEAD).*(/level/15/exec/-/sh/run/CR)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ftptest.cgi?loginuse=&loginpas=)
-            ^<HOST> -.*(GET|POST|HEAD).*(/service/extdirect)
-            ^<HOST> -.*(GET|POST|HEAD).*(/solr/admin/info/system?wt=json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/hudson)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nice*20ports*2C/Tri*6Eity.txt*2ebak)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpMyAdmin/scripts/setup.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wls-wsat/CoordinatorPortType11)
-            ^<HOST> -.*(GET|POST|HEAD).*(/_async/AsyncResponseService)
-            ^<HOST> -.*(GET|POST|HEAD).*(/servicedesk/customer/portals?customize=true)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ws/v1/cluster/apps/new-appli)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cvs/entries)
-            ^<HOST> -.*(GET|POST|HEAD).*(/core/orionsplashscreen.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/console/js/cwcmdialoghead.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/configcommon.cfg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/config/getuser?index=0)
-            ^<HOST> -.*(GET|POST|HEAD).*(/config.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/configurations.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/conf/ssl/apache/integrity.key)
-            ^<HOST> -.*(GET|POST|HEAD).*(/conf/ssl/apache/integrity-smartcenter.key)
-            ^<HOST> -.*(GET|POST|HEAD).*(/connectors)
-            ^<HOST> -.*(GET|POST|HEAD).*(/connector.sds)
-            ^<HOST> -.*(GET|POST|HEAD).*(/consolehelp/default.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/console/js/ctrsrequestparam.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/console/login/loginform.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/contact.asp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/contact.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/contactus.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/contactus.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/controllerweb/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/controlmanager/default.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cool)
-            ^<HOST> -.*(GET|POST|HEAD).*(/_cpanel)
-            ^<HOST> -.*(GET|POST|HEAD).*(/crossdomain.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/+cscoe+/logon.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/csconm/servlet/login/login.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/css.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ct/cx.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ctrlt/deviceupgrade_1)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cutesoft_client/cuteeditor/help/default.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cutesoft_client/cuteeditor/imageeditor/listfiles.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cutesoft_client/cuteeditor/images/log.gif)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cwhp/csmsdesktop/about.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dana-na/../dana/html5acc/guacamole/../../../../../../etc/passwd?/dana/html5acc/guacamole/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dana-na/nc/nc_gina_ver.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/database/print.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/datacenter/downloadapp/showdownload.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/db/admin_yly.sql)
-            ^<HOST> -.*(GET|POST|HEAD).*(/d/bmyadmin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/db.rar)
-            ^<HOST> -.*(GET|POST|HEAD).*(/db.sql)
-            ^<HOST> -.*(GET|POST|HEAD).*(/db.tar.gz)
-            ^<HOST> -.*(GET|POST|HEAD).*(/db.tgz)
-            ^<HOST> -.*(GET|POST|HEAD).*(/db.zip)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dccnojif.asmx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ddem/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/help.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/guestbook.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ewebeditor/ueditor/net/controller.ashx?action=catchimage)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.ds_store)
-            ^<HOST> -.*(GET|POST|HEAD).*(/director)
-            ^<HOST> -.*(GET|POST|HEAD).*(/debug/default/view?panel=config)
-            ^<HOST> -.*(GET|POST|HEAD).*(/default.asp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/default.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/default.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/demo/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/demos/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/demo/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/demo/wp-login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/deployment-config.json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/deploymentmanager/index.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/deptwebsiteaction.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/desktopdirector)
-            ^<HOST> -.*(GET|POST|HEAD).*(/desktopmodules/admin/radeditorprovider/dialoghandler.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dev/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/develop/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/devinfo.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dev/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dfcweb/lib/cupm/nls/applicationproperties.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dialplan.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dl.php?f=../../../../../../../../../../../../etc/passwd)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dms/login.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dndirector)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dndirector/dashboard/show.dn)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dns-query)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dns-query?dns=)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dologin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/downloader)
-            ^<HOST> -.*(GET|POST|HEAD).*(/download.php?f=../../../../../../../../../../../../etc/passwd)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dp/login.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/drupal/sites/all/libraries/mailchimp/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/drupal/sites/default/libraries/mailchimp/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dtlt/home.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/d/txt/test.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dup-installer/main.installer.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/editblackandwhitelist)
-            ^<HOST> -.*(GET|POST|HEAD).*(/edit.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.ef89fdsy98fsd8y9fsd8y9fsd8y9f8sy98ys9)
-            ^<HOST> -.*(GET|POST|HEAD).*(/emsam/index.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/en/main.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/en/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/error_page.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/error.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/etc/passwd)
-            ^<HOST> -.*(GET|POST|HEAD).*(/event/index.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ews/index.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/eyespyfx_large.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/f0w.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/fckeditor/editor/filemanager/connectors/php/upload.php?type=media)
-            ^<HOST> -.*(GET|POST|HEAD).*(/fck/editor/js/fckeditorcode_ie.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/features)
-            ^<HOST> -.*(GET|POST|HEAD).*(/formhandler.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/forum1.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/forum/js/ajax.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/forum.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/forum.php?routestring=ajax/render/widget_php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/forums.php?routestring=ajax/render/widget_php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/geler)
-            ^<HOST> -.*(GET|POST|HEAD).*(/frontend_dev.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.ftpconfig)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ftpsync.settings)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gaestebuch.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gastenboek.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gateway/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gaza.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/g_book.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gb.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/getxml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.git/config)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.git/head)
-            ^<HOST> -.*(GET|POST|HEAD).*(/global.asa)
-            ^<HOST> -.*(GET|POST|HEAD).*(/google_matched_content_blacklist.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/google_matched_content_rules.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/google_matched_content_whitelist.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gponform/diag_form)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gponform/diag_form?images/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/grandstream/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/guestbook)
-            ^<HOST> -.*(GET|POST|HEAD).*(/guestbook.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gui/status)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gulu)
-            ^<HOST> -.*(GET|POST|HEAD).*(/gwadmin-console/login.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/hazelcast/rest/cluster)
-            ^<HOST> -.*(GET|POST|HEAD).*(/hc/admin/login/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/header.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/hello.world)
-            ^<HOST> -.*(GET|POST|HEAD).*(/help.action)
-            ^<HOST> -.*(GET|POST|HEAD).*(/help/contents.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/help/introduction/release-notes.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/?hfsagrs=)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.hg/hgrc)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.hg/requires)
-            ^<HOST> -.*(GET|POST|HEAD).*(/hiking-giardia.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/hnap/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/hnap1/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/hndunblock.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/home/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/home.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/home.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/home.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/home/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/horde/imp/status.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/page.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.php?act=dispmemberloginform)
-            ^<HOST> -.*(GET|POST|HEAD).*(/igsponsor)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.htaccess.~~)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.htaccess~)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.htaccess.bak)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.htaccess.copy)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.htaccess.old)
-            ^<HOST> -.*(GET|POST|HEAD).*(/..htaccess.swp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.htaccess.tmp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/html/en/index.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.htpasswd)
-            ^<HOST> -.*(GET|POST|HEAD).*(/humans.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/humor/www/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/idmprov/jsps/help/help.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/iglp.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/_ignition/execute-solution)
-            ^<HOST> -.*(GET|POST|HEAD).*(/images/login_top.gif)
-            ^<HOST> -.*(GET|POST|HEAD).*(/images/logon_merge.gif)
-            ^<HOST> -.*(GET|POST|HEAD).*(/images.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/images/vuln.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/img.stv2.de/assets/bm/binary/7/9/0/2/7902136bb140d3a7841a2f02b9caca1b_2879?mobile=1.png)
-            ^<HOST> -.*(GET|POST|HEAD).*(/imp/status.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/inc/editor/net/controller.ashx?action=catchimage)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index2.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.exp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.php/component/users/?view=registration)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.php/_login/in)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.php?m=member&c=index&a=register&siteid=1)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.php?option=com_user&task=register)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.php?routestring=ajax/render/widget_php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index.php?s=)
-            ^<HOST> -.*(GET|POST|HEAD).*(/indoxploit.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/info.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/internalserverreporting.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/invoker/ejbinvokerservlet)
-            ^<HOST> -.*(GET|POST|HEAD).*(/invoker/jmxinvokerservlet)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/libraries/joomla/css.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/jsonrpc)
-            ^<HOST> -.*(GET|POST|HEAD).*(/i.pinimg.com/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/i/reviews/ax2.jpg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/is_test)
-            ^<HOST> -.*(GET|POST|HEAD).*(/jax_guestbook.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/jmx-console/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/joomla/administrator)
-            ^<HOST> -.*(GET|POST|HEAD).*(/joomla/web.config.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/js/admin.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/js/device.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/js/hpsum/hpsum-version.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/js/kcfinder/browse.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/js/lib/ccard.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/js/preload/example.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/js/zimbramail/share/model/zmsettings.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/kcfinder/browse.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/koqfnuo.asmx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/kuumuyqj.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/laravel/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/lcds/messagebroker/http)
-            ^<HOST> -.*(GET|POST|HEAD).*(/lcds/messagebroker/httpsecure)
-            ^<HOST> -.*(GET|POST|HEAD).*(/lem/index.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/lesemaus/2018/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/libraries/joomla/jmail.php?u)
-            ^<HOST> -.*(GET|POST|HEAD).*(/libraries/joomla/jmails.php?u)
-            ^<HOST> -.*(GET|POST|HEAD).*(/libs/granite/core/content/login.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/license.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/light.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/links_en.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login.destroy.session)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login/jeecms.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login.jsp/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/loginmsg.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/loginpage.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login_sid.lua)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login/submit/only)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login/submit/onlyy)
-            ^<HOST> -.*(GET|POST|HEAD).*(/logon/fonts/citrix-fonts.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules.php?name=your_account)
-            ^<HOST> -.*(GET|POST|HEAD).*(/menu.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/manager)
-            ^<HOST> -.*(GET|POST|HEAD).*(/l.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/magento2/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/magento2/admin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/magento2/pub/errors/503.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mailgun-php/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/main_internet.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/main/license.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mainui/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/main/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/manager/top.asp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/manga/web/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/manual/ag/contents.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/map/sitemap.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/marvins.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/m/calendar/calendar.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/media-admin.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/media/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/member/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/merchant2/admin.mvc)
-            ^<HOST> -.*(GET|POST|HEAD).*(/messagebroker/http)
-            ^<HOST> -.*(GET|POST|HEAD).*(/messagebroker/httpsecure)
-            ^<HOST> -.*(GET|POST|HEAD).*(/meta.php)
-#            ^<HOST> -.*(GET|POST|HEAD).*(/mm/)
-            ^<HOST> -.*(GET|POST|HEAD).*(./../mnt/custom/productdefinition)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mod_gzip_status)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/autoupgrade/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/gamification/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/mod_simplefileuploadv1.3/elements/clean.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/modules/modules.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/pscartabandonmentpro/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/ps_checkout/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mve/help/en/inventory/am_about.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/myadmin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mstshash=ncrack_user)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mswsmtp/common/authentication/logon.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mybackup/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysql)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysql/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysql/admin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysqladmin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/olux.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nsn/env.bas)
-            ^<HOST> -.*(GET|POST|HEAD).*(/new/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysql/admin/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysql/admin/index.php?lang=en)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysql/index.php?lang=en)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nasapp/nessus/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ncmcontainer.cc)
-            ^<HOST> -.*(GET|POST|HEAD).*(/netbasic/websinfo.bas)
-            ^<HOST> -.*(GET|POST|HEAD).*(/netflow/html/aboutus.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/netmri/config/useradmin/login.tdf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nette.micro?callback=shell_exec&cmd=ifconfig)
-            ^<HOST> -.*(GET|POST|HEAD).*(/new_license.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/new/license.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/newsite/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/news/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/new/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nifi/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nitro/v/config/mps)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nnm/main)
-            ^<HOST> -.*(GET|POST|HEAD).*(/~nobody/etc/passwd)
-            ^<HOST> -.*(GET|POST|HEAD).*(//nonexistanturl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nonexistanturl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nps/servlet/portal)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nps/servlet/portalservice)
-            ^<HOST> -.*(GET|POST|HEAD).*(/nsn/fdir.bas)
-            ^<HOST> -.*(GET|POST|HEAD).*(/null )
-            ^<HOST> -.*(GET|POST|HEAD).*(/ofbizsetup/control/checklogin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/_old/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/old-site/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/old_site/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/oldsite/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/oldsite/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/old-wp/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/old/wp-admin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/old/wp-includes/wlwmanifest.xmly)
-            ^<HOST> -.*(GET|POST|HEAD).*(/operator/basic.shtml?id=1337)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ordermgr/control/checklogin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ords/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/orion/login.asp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/orion/login.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/orion/webresource.axd)
-            ^<HOST> -.*(GET|POST|HEAD).*(/osjdmfjiwdruehnjqfefhrwui)
-            ^<HOST> -.*(GET|POST|HEAD).*(/otrs/index.pl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/owa/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/owa/auth/logon.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/owa/auth/logon.aspx?url=)
-            ^<HOST> -.*(GET|POST|HEAD).*(/page/portal/design_time_pg/welcome)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pages/login.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pages/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/panel/kcfinder/browse.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/panel/tables.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pan_help/en/wwhelp/wwhimpl/common/private/title.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pas.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/passtrixmain.cc)
-            ^<HOST> -.*(GET|POST|HEAD).*(/password)
-            ^<HOST> -.*(GET|POST|HEAD).*(/perl/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sdn/ui/app/index)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sabin/siteadmin.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(../../proc/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plugins/system/debug/debug.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin_bak/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmy-admin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/perl/samples/env.pl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/perl/samples/lancgi.pl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/perl/samples/ndslogin.pl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/perl/samples/volscgi.pl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/perl?-v)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phone/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phonecnf/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phones/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/photo/lang/eng.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpadmin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin0/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin1/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin2/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin2011/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin2012/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin2013/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin2014/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin2015/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin2016/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin2018/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin3/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin_bak/)
-            ^<HOST> -.*(GET|POST|HEAD).*(phpmyadmin_bak/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin/index.php?lang=en)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin/phpmyadmin/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin/url.php?url=)
-            ^<HOST> -.*(GET|POST|HEAD).*(/picdesc.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pi.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/platform-ui/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plugin/ueditor/net/controller.ashx?action=catchimage)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plugs/ueditor/net/controller.ashx?action=catchimage)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plycomconf/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pma2/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pma/print.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/polycom/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/portable-phpmyadmin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/portal/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/portal/redlion)
-            ^<HOST> -.*(GET|POST|HEAD).*(/portal/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/profile/register/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/properties/configuration.php?tab=status)
-            ^<HOST> -.*(GET|POST|HEAD).*(/properties/description.dhtml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/prov/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/provision/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/provisioning/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ptz.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/public/admin/index.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/public/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/public/images/skype/skype_1.gif/1.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rest-service/reviews-v/versioninfo)
-            ^<HOST> -.*(GET|POST|HEAD).*(/qip)
-            ^<HOST> -.*(GET|POST|HEAD).*(/qsoap.qap)
-            ^<HOST> -.*(GET|POST|HEAD).*(/qwe/qwe/index.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rails_info/properties)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rdweb/login/login.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/recoveryconsole/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/reguser.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/remote/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.remote-sync.json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/reporter/client.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/reportserver)
-            ^<HOST> -.*(GET|POST|HEAD).*(/requested.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/res/license.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rev/50btc.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rev/no.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rev/people.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rev/pi.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/+rnum+)
-            ^<HOST> -.*(GET|POST|HEAD).*(/robots.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/root.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/roundcube)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rsaarcher/default.asp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rsaarcher/default.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ruei/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rxr.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/rxr.php?rxr)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sametime/buildinfo.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sapmc/sapmc.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sbb.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sbnqoook.asmx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/scarbook.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/scgi-bin/platform.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/scmadmin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/scripts)
-            ^<HOST> -.*(GET|POST|HEAD).*(/scripts/jquery/maticsoft.jquery.min.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/scripts/wwho.dll)
-            ^<HOST> -.*(GET|POST|HEAD).*(/se/appinfo.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/search/results.stm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/security.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/se/emc_se.swf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/self_upgrade.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sellers.json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/seo-joy.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/server-info)
-            ^<HOST> -.*(GET|POST|HEAD).*(/server/php/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/server-status)
-            ^<HOST> -.*(GET|POST|HEAD).*(/servlet/com.newatlanta.servletexec.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/servlet?m=mod_listener&p=login&q=loginform&jumpto=status)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wordpress/xmlrpc.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/servlet/snoop/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/servlet/snoopservlet/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sess-bin/login_session.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/seter.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/setup.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/setup.cgi?next_file=netgear.cfg&todo=syscmd&cmd=busybox&curpath=/&currentsetting.htm=1)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sftp-config.json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sgdadmin/faces/jsp/version.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shared/userlogin.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shell?busybox)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shell?cd+)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shell?cd+/tmp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shell.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/beez5/error.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/system.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smtime.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sites/all/libraries/elfinder/connectors/php/connector.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/admin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/admin/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/administrator)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/admin/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/admin/login.asp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/admin.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/admin/signin.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/amember/admin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/backend)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/_cpanel)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/index.php?s=admin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/merchant2/admin.mvc)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/sitecore/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/xtadmin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/zencart/admin/admin.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/shop/zencart/admin/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/silverstream)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sip.cfg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sitecore)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sitecore/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sitecorx/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sites/all/libraries/mailchimp/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sites/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sito/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smadmr.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smb_scheduler/cdr.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smconf.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smency.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smftypes.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smhelp.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smmsg.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smquar.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/smsmvlog.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/snmx-cgi/fxm.exe)
-            ^<HOST> -.*(GET|POST|HEAD).*(/snoop/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/snoopservlet/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/soapcaller)
-            ^<HOST> -.*(GET|POST|HEAD).*(/soap:envelope)
-            ^<HOST> -.*(GET|POST|HEAD).*(soap:envelope)
-            ^<HOST> -.*(GET|POST|HEAD).*(/something/maybe/ping)
-            ^<HOST> -.*(GET|POST|HEAD).*(/spa$ma.cfg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/spotfire/about.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/spywall/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/spywall/timeconfig.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sqbcdaysmmxf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/struts/webconsole.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/admin/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sql/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ssp/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/stager)
-            ^<HOST> -.*(GET|POST|HEAD).*(stager)
-            ^<HOST> -.*(GET|POST|HEAD).*(/stager64)
-            ^<HOST> -.*(GET|POST|HEAD).*(stager64)
-            ^<HOST> -.*(GET|POST|HEAD).*(/staging/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/start.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/status.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/status.xsl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/stcenter.nsf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/admin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/admin/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/admin/login.asp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/admin.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/admin/signin.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/amember/admin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/backend)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/store/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/stream/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/stronghold-info)
-            ^<HOST> -.*(GET|POST|HEAD).*(/stronghold-status)
-            ^<HOST> -.*(GET|POST|HEAD).*(/styles.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/subscribe.phpsubscribe.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.svn/entries)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.svn/wc.db)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sws/data/sws_data.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/swvm/consolecontainer.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/syslog.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/system/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/systeminfo)
-            ^<HOST> -.*(GET|POST|HEAD).*(/system/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/system.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/t4.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tbl_add.php?action=)
-            ^<HOST> -.*(GET|POST|HEAD).*(/teamportal/showstudy/show/12.json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/teamportal/trace)
-            ^<HOST> -.*(GET|POST|HEAD).*(/telerik.web.ui.webresource.axd?type=rau)
-            ^<HOST> -.*(GET|POST|HEAD).*(/temp/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/atomic/error.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/atomic/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/beez_20/error.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/beez_20/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/beez3/error.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/beez3/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/beez5/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/beez/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/ja_purity/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/protostar/error.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/protostar/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/rhuk_milkyway/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/system/error.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/system/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/temporary_listen_addresses/smsservice)
-            ^<HOST> -.*(GET|POST|HEAD).*(/test/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/testing)
-            ^<HOST> -.*(GET|POST|HEAD).*(/test/wp-admin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/test/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ui/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ui/faces/login.xhtml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tmp/license.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/test/wp-login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/test wuz here)
-            ^<HOST> -.*(GET|POST|HEAD).*(:test wuz here)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tftboot/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tftpboot/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tftpphone/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tftproot/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/theme1.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/theme.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/this_page_should_not_exist.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/this_server/all_settings.shtml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tightvnc-jviewer.jar)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tmp/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tmpfs/snap.jpg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tmp/vuln.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tmui/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tmunblock.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tools/phpmyadmin/index.ph)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tp/public/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/trace.axd)
-            ^<HOST> -.*(GET|POST|HEAD).*(/trc)
-            ^<HOST> -.*(GET|POST|HEAD).*(/triton-help/en/first.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tsp/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/typo3)
-            ^<HOST> -.*(GET|POST|HEAD).*(/uddi/default.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/uddipublic/default.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ueditor/net/controller.ashx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ueditor/net/controller.ashx?action=catchimage)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ui/login/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/upel.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/upload.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/up.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ups.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/usage/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/usercenter/css/admin/bgimg/admin_all_bg.png)
-            ^<HOST> -.*(GET|POST|HEAD).*(/user/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/userportal/webpages/myaccount/login.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/user/register/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/user_settings.cfg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/user/soapcaller.bs)
-            ^<HOST> -.*(GET|POST|HEAD).*(/usr/lib/cgi-bin/kerbynet)
-            ^<HOST> -.*(GET|POST|HEAD).*(/usr/lib/cgi-bin/test-cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/v1/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/v1/agent/self)
-            ^<HOST> -.*(GET|POST|HEAD).*(/v1/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/v2/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/v2/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/var/resource_config.json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vb5/js/ajax.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vbforum/js/ajax.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vbulletin/js/ajax.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vendor/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vendor/phpunit/phpunit/license)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vendor/phpunit/phpunit/src/util/php/xsamxadoo_bot.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vsyfgtyt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/version)
-            ^<HOST> -.*(GET|POST|HEAD).*(/view/hsrindex.shtml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/view.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/view/view.shtml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vncviewer.jar)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vpns/cfg/smb.conf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vpn/../vpns/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vpn/../vpns/cfg/smb.conf)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.vscode/ftp-sync.json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.vscode/sftp.json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/vsmc.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/_vti_bin/fpcount.exe)
-            ^<HOST> -.*(GET|POST|HEAD).*(/_vti_bin/shtml.dll/_vti_rpc)
-            ^<HOST> -.*(GET|POST|HEAD).*(/w00tw00t)
-            ^<HOST> -.*(GET|POST|HEAD).*(/w00tw00t.at.isc.sans.dfind)
-            ^<HOST> -.*(GET|POST|HEAD).*(/w0rm.html.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wallet.dat)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wanipcn.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wavemaster.internal)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wcd/system.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/web/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/web2/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webalizer/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webapps/login/index.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webbuilder/script/locale/wb-lang-zh_cn.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webui/apps/sdcss)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webcam/webcam.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/web.config)
-            ^<HOST> -.*(GET|POST|HEAD).*(/web.config.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/web-console/serverinfo.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webconsole/webpages/login.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webct/about.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webdb)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webfig/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webhost)
-            ^<HOST> -.*(GET|POST|HEAD).*(/./web-inf/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/web/phpmyadmin/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/website/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/website/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/website/wp-login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/web/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.well-known/autoconfig/mail/config-v1.1.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wls_utc/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wls-wsat/coordinatorporttype)
-            ^<HOST> -.*(GET|POST|HEAD).*(/woorewards)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wordpress/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wordpress2/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wordpress/license.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wordpress/readme.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wordpress/wp-admin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wordpress/wp-admin/install.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wordpress/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wos.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-1ogin_bak.php?eanver=phpcode)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp1/wp-login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp2/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp2/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp2/xmlrpc.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-404.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-acess.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-action.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-admin/admin-ajax.php?action=duplicator_download&file=../wp-config.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-admine.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-admin/install.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-admin/network/wp-footer.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-admin/shapes.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-adm.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-anyconf.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-back.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-blog-mail.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-blog.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.bak)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.old)
-            ^<HOST> -.*(GET|POST|HEAD).*(../wp-config.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php~)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php.bak)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php.dist)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php.inc)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php.orig)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php.original)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php.save)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php.swp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-conf.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/addfreestats/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/add-linked-images-to-gallery-v01/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/addon-library/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/add-tags-and-category-to-page/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/add-to-any/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/add-to-any-subscribe/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/add-widget-after-content/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/adkingpro/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/admin-bar-dashboard-control/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/admin-category-filter/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/admin-collapse-subpages/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/admin-in-english/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/admin-page-spider/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/admin-trim-interface/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/adsense-in-post-ads-by-oizuled/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/adsense-plugin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/advanced-cron-manager/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/advanced-css-editor/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/advanced-custom-fields-location-field-add-on/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/advanced-permalinks/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/advanced-post-list/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/advanced-product-labels-for-woocommerce/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/advanced-reporting-for-woocommerce/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/advanced-text-widget/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/advanced-tinymce-configuration/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/adwords-conversion-tracking-code/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/aesop-story-engine/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/affiliates/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/age-gate/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/agile-crm-lead-management/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/agile-store-locator/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/ai-responsive-gallery-album/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/ajax-adsense/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/another-wordpress-classifieds-plugin/awpcp.po)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/apikey)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/background-image-cropper/content-post.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/baggage-freight/readme.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/cimy-user-extra-fields/readme_official.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/complete-gallery-manager/frames/upload-images.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/contabileads/integracoes/mautic/api-library/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/contus-hd-flv-player/uploadvideo.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/delucks-seo/readme.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/downloads-manager/img/unlock.gif)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/dzs-videogallery/class_parts/vendor/phpunit/phpunit/build)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/font-uploader/fontfunctions/fu_script.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/mm-plugin/inc/vendors/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/page-flip-image-gallery/upload.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/photo-gallery/filemanager/uploadhandler.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/ppus/up.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/realia/libraries/paypal-php-sdk/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/tevolution/tmplconnector/monetize/templatic-custom_fields/css/jquery.lightbox.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/html404/index.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/ioptimization)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/ioptimization/ioptimize.php?rchk)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/jekyll-exporter/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/jquery-html5-file-upload/readme.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/mac-dock-gallery/readme.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/magic-fields/mf_constant.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/mailcwp/mailcwp-upload.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/mm-forms-community/includes/ajaxfileupload.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wsi.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wso.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ws.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/uploads/wpcf7_uploads/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/theme-configurator/mini.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/tourmaster/include/authorize/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/ubh/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/upspy/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/vwcleanerplugin/bump.php?cache)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/widget-logic/mini.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/wp-file-manager)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/wp-file-manager/lib/php/connector.minimal.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/wp-file-manager/readme.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/xichang/x.php?xi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/vuln.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/wp-1ogin_bak.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-includes/css/modules.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-info.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-json/wp_live_chat_support/v1/get_status)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-json/wp/v2/users)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-links.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-login.php?action=register)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-mains.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-on.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-test/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wptest/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp/wp-admin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp_wrong_da)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wsusadmin/errors/browsersettings.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ws_utc/login.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wwos.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/www/license.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/www/phpmyadmin/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/www/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x00cookie:)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x22jdatabasedrivermysqli)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x22jsimplepiefactory)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x22simplepie)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x5c0disconnecthandlers)
-            ^<HOST> -.*(GET|POST|HEAD).*(/xampp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/xampp/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/xmlr)
-            ^<HOST> -.*(GET|POST|HEAD).*(/xxx.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/y000000000000.cfg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/theme-configurator/mini.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/tourmaster/include/authorize/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/ubh/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/upspy/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/vwcleanerplugin/bump.php?cache)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/widget-logic/mini.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/wp-file-manager)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/wp-file-manager/lib/php/connector.minimal.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/wp-file-manager/readme.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/build.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/plugins/xichang/x.php?xi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-content/themes/satoshi/upload-file.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/y000000000004.cfg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/yabb.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/yabb.pl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/yapgb.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/yapgb.php/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/yealink/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/yybbs.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/zencart/admin/admin.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/zencart/admin/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.bzr/branch  format)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.bzr/repository/format)
-            ^<HOST> -.*(GET|POST|HEAD).*(/chassis/config/generalchassisconfig.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/chat/common/server/php/file.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ckeditor/kcfinder/browse.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/client/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/clientaccesspolicy.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/clientpage.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/_cms/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cms/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cms/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.cobalt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/comments.phptrackback)
-            ^<HOST> -.*(GET|POST|HEAD).*(/common/about.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/com/novell/webaccess/webaccessuninstall.ini)
-            ^<HOST> -.*(GET|POST|HEAD).*(/components/com_b2jcontact/izoc.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/component/users/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/config.exp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/mainfunction.cg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/printenv)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/test-cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/weblogin.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi/execute)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi/guestbook?page=1)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-mod/index.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/ctrldirect.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/filescan)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/file_transfer.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/guestimage.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/index.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/kerbynet?Action=Render&Object=StartSession)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/kerbynet?action=x509view)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/kerbynet?section=)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/login.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/c/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cachepages/hiking-safety.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/card_scan_decoder.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cas/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/catalog/adminhtml_categor)
-            ^<HOST> -.*(GET|POST|HEAD).*(/caucho-status)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cfg/000000000000.cfg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cfide/administrator/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cfide/administrator/index.cfm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cfide/administrator/settings/version.cfm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/camctrl.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bbs.php?routestring=ajax/render/widget_php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bd.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blogadmin/wp-admin/ )
-            ^<HOST> -.*(GET|POST|HEAD).*(/blogbackup/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/boaform/admin/formlogin?username=)
-            ^<HOST> -.*(GET|POST|HEAD).*(/boaform/admin/formlogin?username=adminisp&psd=adminisp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/boaform/admin/formlogin?username=admin&psd=admin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/boaform/admin/formlogin?username=ec8&psd=ec8)
-            ^<HOST> -.*(GET|POST|HEAD).*(/boaform/admin/formping)
-            ^<HOST> -.*(GET|POST|HEAD).*(/book.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/brightmail/viewlogin.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/builtin/index.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/buysticker. php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/buysticker.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blog/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blogg/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blogs/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blog/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blog/wp-json/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blog/wp-login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blog/xmlrpc.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/boaform/admin/forming)
-            ^<HOST> -.*(GET|POST|HEAD).*(/boaform/admin/formlogin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bea_wls_deployment_internal)
-            ^<HOST> -.*(GET|POST|HEAD).*(/beta/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/beta/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/.bitcoin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bitcoin.dat)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bladeacss.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bla.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blazeds/messagebroker/http)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blazeds/messagebroker/httpsecure)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blog/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blog2/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/assets/admin/ckeditor/kcfinder/browse.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/assets/ckeditor/kcfinder/browse.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/assets/images/accesson.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/assets/js/kcfinder/browse.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/assets/kcfinder/browse.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/assets/ueditor/net/controller.ashx?action=catchimage)
-            ^<HOST> -.*(GET|POST|HEAD).*(/asterisk/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ata/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/authenticate/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/authentication/login/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/auth/login)
-            ^<HOST> -.*(GET|POST|HEAD).*(/aztgear.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/back/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backend/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/back/license.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backup/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backup.rar)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backup.sql)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backup.tar.gz)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backup.tgz)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backup/wp-admin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backup/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backup/wp-login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/backup.zip)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bak/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/baselining/version)
-            ^<HOST> -.*(GET|POST|HEAD).*(/base.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bavbulysuhlw)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bbs.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bbs/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bbs.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/autodiscover/autodiscover.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/autopass/login_input)
-            ^<HOST> -.*(GET|POST|HEAD).*(/av-centerd)
-            ^<HOST> -.*(GET|POST|HEAD).*(/axis/directdownload.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/98820b975faf1aa0b4400370ab1d3a)
-            ^<HOST> -.*(GET|POST|HEAD).*(/api/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/api.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/api.php?key=1)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app-ads.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/.bzr/branch-format)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/.bzr/repository/format)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/.git/config)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/idxasp.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/js/source/wcmlib/wcmconstants.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/appliance/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/apps/guestbook)
-            ^<HOST> -.*(GET|POST|HEAD).*(/apps/zxtm/login.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/tpl/fanwe_1/js/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/ui/login.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app.zip)
-            ^<HOST> -.*(GET|POST|HEAD).*(/arx/license.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/aska.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/a2billing/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin2aa51c95/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin65193f2d/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin.back)
-            ^<HOST> -.*(GET|POST|HEAD).*(/adminc8a0b48b/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/ckeditor/kcfinder/browse.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/common/helplinks.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/config.php/admincp/login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/.env)
-            ^<HOST> -.*(GET|POST|HEAD).*(/adminer-4.0.0.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/adminer.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/ewebeditor/ueditor/net/controller.ashx?action=catchimage)
-            ^<HOST> -.*(GET|POST|HEAD).*(/install/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/administrator/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/administrator/help/en-gb/toc.json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/administrator/templates/bluestork/error.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/administrator/templates/bluestork/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/administrator)
-            ^<HOST> -.*(GET|POST|HEAD).*(/a2billing/admin/public/index.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/a2billing/admin/public/pp_error.php?c=accessdenied)
-            ^<HOST> -.*(GET|POST|HEAD).*(/a2billing/customer/templates/default/footer.tpl)
-            ^<HOST> -.*(GET|POST|HEAD).*(/aastra.cfg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/about.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/about.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/aboutprinter.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/accesson.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/active.log)
-            ^<HOST> -.*(GET|POST|HEAD).*(/administrator/index\.php.*500)
-            ^<HOST> -.*(GET|POST|HEAD).*(/:8880/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/addons/theme/stv1/_static/image/favicon\.ico)
-            ^<HOST> -.*(GET|POST|HEAD).*(/addons/theme/stv1/_static/ts2/layout\.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/addons/theme/stv2/_static/ts2/layout\.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/Admin/Common/HelpLinks\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin-console)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/inc/xml\.xslt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/administrator/components/com_xcloner-backupandrestore/index2\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/administrator/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/administrator/manifests/files/joomla\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/mysql2/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/mysql/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/phpMyAdmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/pma/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/PMA/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/SouthidcEditor/ButtonImage/standard/componentmenu\.gif)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/SouthidcEditor/Dialog/dialog\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/SouthidcEditor/ewebeditor\.asp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/API/DW/Dwplugin/SystemLabel/SiteConfig\.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/API/DW/Dwplugin/TemplateManage/login_site\.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/API/DW/Dwplugin/TemplateManage/manage_site\.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/API/DW/Dwplugin/TemplateManage/save_template\.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/API/DW/Dwplugin/ThirdPartyTags/SiteFactory\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/home/skins/default/style\.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/js/source/wcmlib/WCMConstants\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/apple-app-site-association)
-            ^<HOST> -.*(GET|POST|HEAD).*(/app/Tpl/fanwe_1/js/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/_asterisk/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/bencandy\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/blog/administrator/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi-bin/php5)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cgi/common\.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/CGI/Execute)
-            ^<HOST> -.*(GET|POST|HEAD).*(/check\.proxyradar\.com/azenv\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ckeditor/ckfinder/ckfinder\.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ckeditor/ckfinder/install\.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ckfinder/ckfinder\.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ckfinder/install\.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ckupload\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/claroline/phpMyAdmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/clases\.gone\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/cms/administrator)
-            ^<HOST> -.*(GET|POST|HEAD).*(/command\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/components/com_adsmanager/js/fullnoconflict\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/components/com_b2jcontact/css/b2jcontact\.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/components/com_b2jcontact/router\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/components/com_foxcontact/js/jtext\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/components/com_sexycontactform/assets/js/index\.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/console/auth/reg_newuser\.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/console/include/not_login\.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/console/js/CTRSRequestParam\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/console/js/CWCMDialogHead\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/currentsetting\.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/CuteSoft_Client/CuteEditor/Help/default\.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/CuteSoft_Client/CuteEditor/ImageEditor/listfiles\.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/CuteSoft_Client/CuteEditor/Images/log\.gif)
-            ^<HOST> -.*(GET|POST|HEAD).*(/data/admin/ver\.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/datacenter/downloadApp/showDownload\.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/db/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dbadmin/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/dbadmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/db/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/deptWebsiteAction\.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/eams/static/scripts/grade/course/input\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/editor/js/fckeditorcode_ie\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/examples/file-manager\.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/getcfg\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/get_password\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/\.git/info/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/Hello\.World)
-            ^<HOST> -.*(GET|POST|HEAD).*(/hndUnblock\.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/images/login9/login_33\.jpg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/include/dialog/config\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/include/install_ocx\.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/index\.action)
-            ^<HOST> -.*(GET|POST|HEAD).*(/ip_js\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/issmall/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/jenkins/script)
-            ^<HOST> -.*(GET|POST|HEAD).*(/jm-ajax/upload_file/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/jmx-console)
-            ^<HOST> -.*(GET|POST|HEAD).*(/js/tools\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/libraries/sfn\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(login\.destroy\.session)
-            ^<HOST> -.*(GET|POST|HEAD).*(/login/Jeecms\.do)
-            ^<HOST> -.*(GET|POST|HEAD).*(/logo_img\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/maintlogin\.jsp)
-            ^<HOST> -.*(GET|POST|HEAD).*(/manager/html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/manager/status)
-            ^<HOST> -.*(GET|POST|HEAD).*(/master/login\.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/media/com_hikashop/js/hikashop\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/attributewizardpro/config\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/columnadverts/config\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/fieldvmegamenu/config\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/homepageadvertise2/config\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/homepageadvertise/config\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/mod_simplefileuploadv1\.3/elements/udd\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/pk_flexmenu/config\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/pk_vertflexmenu/config\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/modules/wdoptionpanel/config\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/msd)
-            ^<HOST> -.*(GET|POST|HEAD).*(/msd1\.24\.4)
-            ^<HOST> -.*(GET|POST|HEAD).*(/msd1\.24stable)
-            ^<HOST> -.*(GET|POST|HEAD).*(mstshash=NCRACK_USER)
-            ^<HOST> -.*(GET|POST|HEAD).*(/muieblackcat)
-            ^<HOST> -.*(GET|POST|HEAD).*(/myadmin2/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/myadmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/myadmin/scripts/setup\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/MyAdmin/scripts/setup\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysql-admin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysqladmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mysqldumper)
-            ^<HOST> -.*(GET|POST|HEAD).*(/mySqlDumper)
-            ^<HOST> -.*(GET|POST|HEAD).*(/MySQLDumper)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpadmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpma/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpMyadmin_bak/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpMyAdmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpMyAdmin/phpMyAdmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/phpMyAdmin/scripts/setup\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plugins/anchor/anchor\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plugins/filemanager/filemanager/js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plus/download\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plus/heightsearch\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plus/rssmap\.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/plus/sitemap\.html)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pma/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/PMA/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/PMA2/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pma/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/PMA/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pmamy2/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pmamy/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pma-old/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pma/scripts/setup\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/pmd/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/privacy\.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/resources/style/images/login/btn\.png)
-            ^<HOST> -.*(GET|POST|HEAD).*(/Scripts/jquery/maticsoft\.jquery\.min\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/script/valid_formdata\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/siteserver/login\.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/siteserver/upgrade/default\.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(soap:Envelope)
-            ^<HOST> -.*(GET|POST|HEAD).*(/stalker_portal/server/adm/tv-channels/iptv-list-json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/stalker_portal/server/adm/users/users-list-json)
-            ^<HOST> -.*(GET|POST|HEAD).*(/stssys\.htm)
-            ^<HOST> -.*(GET|POST|HEAD).*(/sys\.cache\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/system/assets/jquery/jquery-2\.x\.min\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/template/1/bluewise/_files/jspxcms\.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/templates/jsn_glass_pro/ext/hikashop/jsn_ext_hikashop\.css)
-            ^<HOST> -.*(GET|POST|HEAD).*(/test_404_page/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/test_for_404/)
-            ^<HOST> -.*(GET|POST|HEAD).*(Test Wuz Here)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tmUnblock\.cgi)
-            ^<HOST> -.*(GET|POST|HEAD).*(/tools/phpMyAdmin/index\.ph)
-            ^<HOST> -.*(GET|POST|HEAD).*(/uc_server/control/admin/db\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/upload/bank-icons/)
-            ^<HOST> -.*(GET|POST|HEAD).*(/UserCenter/css/admin/bgimg/admin_all_bg\.png)
-            ^<HOST> -.*(GET|POST|HEAD).*(/\.user\.ini)
-            ^<HOST> -.*(GET|POST|HEAD).*(\.bitcoin)
-            ^<HOST> -.*(GET|POST|HEAD).*(wallet\.dat)
-            ^<HOST> -.*(GET|POST|HEAD).*(bitcoin\.dat)
-            ^<HOST> -.*(GET|POST|HEAD).*(/magento2/admin)
-            ^<HOST> -.*(GET|POST|HEAD).*(/user/register?element_parents=account)
-            ^<HOST> -.*(GET|POST|HEAD).*(/user/themes/antimatter/js/antimatter\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/user/themes/antimatter/js/modernizr\.custom\.71422\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/user/themes/antimatter/js/slidebars\.min\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/w00tw00t)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webbuilder/script/locale/wb-lang-zh_CN\.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/web-console)
-            ^<HOST> -.*(GET|POST|HEAD).*(/webdav)
-            ^<HOST> -.*(GET|POST|HEAD).*(/web/phpMyAdmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/whir_system/login\.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/whir_system/module/security/login\.aspx)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wls-wsat/CoordinatorPortType)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wpbase/url\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-includes/wlwmanifest\.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/wp-login\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/www/phpMyAdmin/index\.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x00Cookie:)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x22cache_name_function)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x22JDatabaseDriverMysqli)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x22JSimplepieFactory)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x22sanitize)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x22SimplePie)
-            ^<HOST> -.*(GET|POST|HEAD).*(\x5C0disconnectHandlers)
-            ^<HOST> -.*(GET).*(\.\./wp-config.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/admin/assets/js/views/login.js)
-            ^<HOST> -.*(GET|POST|HEAD).*(/000000000000.cfg)
-            ^<HOST> -.*(GET|POST|HEAD).*(/098.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/0.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/123.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/1/license.txt)
-            ^<HOST> -.*(GET|POST|HEAD).*(/1.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/1/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/2018/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/2019/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/2019/wp-login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/2020/wp-login.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/2.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/2/wp-includes/wlwmanifest.xml)
-            ^<HOST> -.*(GET|POST|HEAD).*(/50btc.php)
-            ^<HOST> -.*(GET|POST|HEAD).*(/65193f2d/admin.php)
+prefregex = ^<HOST> -[^"]*\"(?:GET|POST|HEAD)\s+<F-CONTENT>\S+</F-CONTENT> HTTP/[^"]+" 40\d\s\d+
 
+failregex = ^/\.git/config
+            ^/api/jsonws/invoke
+            ^/?a=fetch&content=<php>die(@md5(HelloThinkCMF))</php>
+            ^/?XDEBUG_SESSION_START=phpstorm
+            ^/mifs/.;/services/LogService
+            ^/solr/admin/info/system?wt=json
+            ^/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php
+            ^/ws/v1/cluster/apps/new-application
+            ^/level/15/exec/-/sh/run/CR
+            ^/ftptest.cgi?loginuse=&loginpas=
+            ^/service/extdirect
+            ^/solr/admin/info/system?wt=json
+            ^/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php
+            ^/hudson
+            ^/wp-config.php
+            ^/nice*20ports*2C/Tri*6Eity.txt*2ebak
+            ^/phpMyAdmin/scripts/setup.php
+            ^/wls-wsat/CoordinatorPortType11
+            ^/_async/AsyncResponseService
+            ^/servicedesk/customer/portals?customize=true
+            ^/ws/v1/cluster/apps/new-appli
+            ^/cvs/entries
+            ^/core/orionsplashscreen.do
+            ^/console/js/cwcmdialoghead.js
+            ^/configcommon.cfg
+            ^/config/getuser?index=0
+            ^/config.php
+            ^/configurations.do
+            ^/conf/ssl/apache/integrity.key
+            ^/conf/ssl/apache/integrity-smartcenter.key
+            ^/connectors
+            ^/connector.sds
+            ^/consolehelp/default.jsp
+            ^/console/js/ctrsrequestparam.js
+            ^/console/login/loginform.jsp
+            ^/contact.asp
+            ^/contact.aspx
+            ^/contactus.aspx
+            ^/contactus.jsp
+            ^/controllerweb/
+            ^/controlmanager/default.htm
+            ^/cool
+            ^/_cpanel
+            ^/crossdomain.xml
+            ^/+cscoe+/logon.html
+            ^/csconm/servlet/login/login.jsp
+            ^/css.php
+            ^/ct/cx.php
+            ^/ctrlt/deviceupgrade_1
+            ^/cutesoft_client/cuteeditor/help/default.htm
+            ^/cutesoft_client/cuteeditor/imageeditor/listfiles.aspx
+            ^/cutesoft_client/cuteeditor/images/log.gif
+            ^/cwhp/csmsdesktop/about.jsp
+            ^/dana-na/../dana/html5acc/guacamole/../../../../../../etc/passwd?/dana/html5acc/guacamole/
+            ^/dana-na/nc/nc_gina_ver.txt
+            ^/database/print.css
+            ^/datacenter/downloadapp/showdownload.do
+            ^/db/admin_yly.sql
+            ^/d/bmyadmin
+            ^/db.rar
+            ^/db.sql
+            ^/db.tar.gz
+            ^/db.tgz
+            ^/db.zip
+            ^/dccnojif.asmx
+            ^/ddem/
+            ^/help.php
+            ^/guestbook.php
+            ^/ewebeditor/ueditor/net/controller.ashx?action=catchimage
+            ^/.ds_store
+            ^/director
+            ^/debug/default/view?panel=config
+            ^/default.asp
+            ^/default.aspx
+            ^/default.php
+            ^/demo/
+            ^/demos/
+            ^/demo/wp-includes/wlwmanifest.xml
+            ^/demo/wp-login.php
+            ^/deployment-config.json
+            ^/deploymentmanager/index.jsp
+            ^/deptwebsiteaction.do
+            ^/desktopdirector
+            ^/desktopmodules/admin/radeditorprovider/dialoghandler.aspx
+            ^/dev/
+            ^/develop/
+            ^/devinfo.xml
+            ^/dev/wp-includes/wlwmanifest.xml
+            ^/dfcweb/lib/cupm/nls/applicationproperties.js
+            ^/dialplan.xml
+            ^/dl.php?f=../../../../../../../../../../../../etc/passwd
+            ^/dms/login.jsp
+            ^/dndirector
+            ^/dndirector/dashboard/show.dn
+            ^/dns-query
+            ^/dns-query?dns=
+            ^/dologin
+            ^/downloader
+            ^/download.php?f=../../../../../../../../../../../../etc/passwd
+            ^/dp/login.xml
+            ^/drupal/sites/all/libraries/mailchimp/vendor/phpunit/phpunit/build.xml
+            ^/drupal/sites/default/libraries/mailchimp/vendor/phpunit/phpunit/build.xml
+            ^/dtlt/home.html
+            ^/d/txt/test.txt
+            ^/dup-installer/main.installer.php
+            ^/editblackandwhitelist
+            ^/edit.php
+            ^/.ef89fdsy98fsd8y9fsd8y9fsd8y9f8sy98ys9
+            ^/emsam/index.html
+            ^/en/main.js
+            ^/.env
+            ^/en/wp-includes/wlwmanifest.xml
+            ^/error_page.htm
+            ^/error.php
+            ^/etc/passwd
+            ^/event/index.do
+            ^/ews/index.htm
+            ^/eyespyfx_large.jsp
+            ^/f0w.php
+            ^/fckeditor/editor/filemanager/connectors/php/upload.php?type=media
+            ^/fck/editor/js/fckeditorcode_ie.js
+            ^/features
+            ^/formhandler.cgi
+            ^/forum1.php
+            ^/forum/js/ajax.js
+            ^/forum.php
+            ^/forum.php?routestring=ajax/render/widget_php
+            ^/forums.php?routestring=ajax/render/widget_php
+            ^/geler
+            ^/frontend_dev.php
+            ^/.ftpconfig
+            ^/ftpsync.settings
+            ^/gaestebuch.php
+            ^/gastenboek.php
+            ^/gateway/login
+            ^/gaza.php
+            ^/g_book.cgi
+            ^/gb.php
+            ^/getxml
+            ^/.git/config
+            ^/.git/head
+            ^/global.asa
+            ^/google_matched_content_blacklist.txt
+            ^/google_matched_content_rules.xml
+            ^/google_matched_content_whitelist.txt
+            ^/gponform/diag_form
+            ^/gponform/diag_form?images/
+            ^/grandstream/
+            ^/guestbook
+            ^/guestbook.html
+            ^/gui/status
+            ^/gulu
+            ^/gwadmin-console/login.jsp
+            ^/hazelcast/rest/cluster
+            ^/hc/admin/login/
+            ^/header.php
+            ^/hello.world
+            ^/help.action
+            ^/help/contents.htm
+            ^/help/introduction/release-notes.html
+            ^/?hfsagrs=
+            ^/.hg/hgrc
+            ^/.hg/requires
+            ^/hiking-giardia.php
+            ^/hnap/
+            ^/hnap1/
+            ^/hndunblock.cgi
+            ^/home/
+            ^/home.do
+            ^/home.htm
+            ^/home.php
+            ^/home/wp-includes/wlwmanifest.xml
+            ^/horde/imp/status.php
+            ^/page.php
+            ^/index.php?act=dispmemberloginform
+            ^/igsponsor
+            ^/.htaccess.~~
+            ^/.htaccess~
+            ^/.htaccess.bak
+            ^/.htaccess.copy
+            ^/.htaccess.old
+            ^/..htaccess.swp
+            ^/.htaccess.tmp
+            ^/html/en/index.htm
+            ^/.htpasswd
+            ^/humans.txt
+            ^/humor/www/wp-includes/wlwmanifest.xml
+            ^/idmprov/jsps/help/help.jsp
+            ^/iglp.php
+            ^/_ignition/execute-solution
+            ^/images/login_top.gif
+            ^/images/logon_merge.gif
+            ^/images.php
+            ^/images/vuln.php
+            ^/img.stv2.de/assets/bm/binary/7/9/0/2/7902136bb140d3a7841a2f02b9caca1b_2879?mobile=1.png
+            ^/imp/status.php
+            ^/inc/editor/net/controller.ashx?action=catchimage
+            ^/index2.php
+            ^/index.aspx
+            ^/index.do
+            ^/index.exp
+            ^/index.jsp
+            ^/index.php/component/users/?view=registration
+            ^/index.php/_login/in
+            ^/index.php?m=member&c=index&a=register&siteid=1
+            ^/index.php?option=com_user&task=register
+            ^/index.php?routestring=ajax/render/widget_php
+            ^/index.php?s=
+            ^/indoxploit.php
+            ^/info.php
+            ^/internalserverreporting.php
+            ^/invoker/ejbinvokerservlet
+            ^/invoker/jmxinvokerservlet
+            ^/login.html
+            ^/libraries/joomla/css.php
+            ^/jsonrpc
+            ^/i.pinimg.com/
+            ^/i/reviews/ax2.jpg
+            ^/is_test
+            ^/jax_guestbook.php
+            ^/jmx-console/
+            ^/joomla/administrator
+            ^/joomla/web.config.txt
+            ^/js/admin.js
+            ^/js/device.js
+            ^/js/hpsum/hpsum-version.js
+            ^/js/kcfinder/browse.php
+            ^/js/lib/ccard.js
+            ^/js/preload/example.txt
+            ^/js/zimbramail/share/model/zmsettings.js
+            ^/kcfinder/browse.php
+            ^/koqfnuo.asmx
+            ^/kuumuyqj.aspx
+            ^/laravel/.env
+            ^/lcds/messagebroker/http
+            ^/lcds/messagebroker/httpsecure
+            ^/lem/index.html
+            ^/lesemaus/2018/wp-includes/wlwmanifest.xml
+            ^/libraries/joomla/jmail.php?u
+            ^/libraries/joomla/jmails.php?u
+            ^/libs/granite/core/content/login.html
+            ^/license.php
+            ^/light.cgi
+            ^/links_en.html
+            ^/login.cgi
+            ^/login.destroy.session
+            ^/login.do
+            ^/login.htm
+            ^/login/jeecms.do
+            ^/login.jsp/
+            ^/login/login
+            ^/loginmsg.js
+            ^/loginpage.do
+            ^/login.php
+            ^/login_sid.lua
+            ^/login/submit/only
+            ^/login/submit/onlyy
+            ^/logon/fonts/citrix-fonts.css
+            ^/modules.php?name=your_account
+            ^/menu.htm
+            ^/manager
+            ^/l.php
+            ^/magento2/
+            ^/magento2/admin/
+            ^/magento2/pub/errors/503.php
+            ^/mailgun-php/vendor/phpunit/phpunit/build.xml
+            ^/main_internet.php
+            ^/main/license.txt
+            ^/mainui/
+            ^/main/wp-includes/wlwmanifest.xml
+            ^/manager/top.asp
+            ^/manga/web/wp-includes/wlwmanifest.xml
+            ^/manual/ag/contents.htm
+            ^/map/sitemap.xml
+            ^/marvins.php
+            ^/m/calendar/calendar.html
+            ^/media-admin.php
+            ^/media/wp-includes/wlwmanifest.xml
+            ^/member/
+            ^/merchant2/admin.mvc
+            ^/messagebroker/http
+            ^/messagebroker/httpsecure
+            ^/meta.php
+#            ^/mm/
+            ^./../mnt/custom/productdefinition
+            ^/mod_gzip_status
+            ^/modules/autoupgrade/vendor/phpunit/phpunit/build.xml
+            ^/modules/gamification/vendor/phpunit/phpunit/build.xml
+            ^/modules/mod_simplefileuploadv1.3/elements/clean.php
+            ^/modules/modules/modules.php
+            ^/modules/pscartabandonmentpro/vendor/phpunit/phpunit/build.xml
+            ^/modules/ps_checkout/vendor/phpunit/phpunit/build.xml
+            ^/mve/help/en/inventory/am_about.html
+            ^/myadmin
+            ^/mstshash=ncrack_user
+            ^/mswsmtp/common/authentication/logon.aspx
+            ^/mybackup/
+            ^/mysql
+            ^/mysql/
+            ^/mysql/admin
+            ^/mysqladmin
+            ^/olux.php
+            ^/nsn/env.bas
+            ^/new/
+            ^/mysql/admin/index.php
+            ^/mysql/admin/index.php?lang=en
+            ^/mysql/index.php?lang=en
+            ^/nasapp/nessus/
+            ^/ncmcontainer.cc
+            ^/netbasic/websinfo.bas
+            ^/netflow/html/aboutus.jsp
+            ^/netmri/config/useradmin/login.tdf
+            ^/nette.micro?callback=shell_exec&cmd=ifconfig
+            ^/new_license.php
+            ^/new/license.txt
+            ^/newsite/wp-includes/wlwmanifest.xml
+            ^/news/wp-includes/wlwmanifest.xml
+            ^/new/wp-includes/wlwmanifest.xml
+            ^/nifi/
+            ^/nitro/v/config/mps
+            ^/nnm/main
+            ^/~nobody/etc/passwd
+            ^//nonexistanturl
+            ^/nonexistanturl
+            ^/nps/servlet/portal
+            ^/nps/servlet/portalservice
+            ^/nsn/fdir.bas
+            ^/null 
+            ^/ofbizsetup/control/checklogin
+            ^/_old/
+            ^/old-site/
+            ^/old_site/
+            ^/oldsite/
+            ^/oldsite/wp-includes/wlwmanifest.xml
+            ^/old-wp/
+            ^/old/wp-admin/
+            ^/old/wp-includes/wlwmanifest.xmly
+            ^/operator/basic.shtml?id=1337
+            ^/ordermgr/control/checklogin
+            ^/ords/
+            ^/orion/login.asp
+            ^/orion/login.aspx
+            ^/orion/webresource.axd
+            ^/osjdmfjiwdruehnjqfefhrwui
+            ^/otrs/index.pl
+            ^/owa/
+            ^/owa/auth/logon.aspx
+            ^/owa/auth/logon.aspx?url=
+            ^/page/portal/design_time_pg/welcome
+            ^/pages/login.htm
+            ^/pages/login.php
+            ^/panel/kcfinder/browse.php
+            ^/panel/tables.php
+            ^/pan_help/en/wwhelp/wwhimpl/common/private/title.js
+            ^/pas.php
+            ^/passtrixmain.cc
+            ^/password
+            ^/perl/
+            ^/sdn/ui/app/index
+            ^/sabin/siteadmin.htm
+            ^../../proc/
+            ^/plugins/system/debug/debug.xml
+            ^/phpmyadmin_bak/index.php
+            ^/phpmy-admin/
+            ^/perl/samples/env.pl
+            ^/perl/samples/lancgi.pl
+            ^/perl/samples/ndslogin.pl
+            ^/perl/samples/volscgi.pl
+            ^/perl?-v
+            ^/phone/
+            ^/phonecnf/
+            ^/phones/
+            ^/photo/lang/eng.js
+            ^/phpadmin
+            ^/phpmyadmin0/
+            ^/phpmyadmin1/
+            ^/phpmyadmin2/
+            ^/phpmyadmin2011/
+            ^/phpmyadmin2012/
+            ^/phpmyadmin2013/
+            ^/phpmyadmin2014/
+            ^/phpmyadmin2015/
+            ^/phpmyadmin2016/
+            ^/phpmyadmin2018/
+            ^/phpmyadmin3/
+            ^/phpmyadmin_bak/
+            ^phpmyadmin_bak/index.php
+            ^/phpmyadmin/index.php?lang=en
+            ^/phpmyadmin/phpmyadmin/index.php
+            ^/phpmyadmin/url.php?url=
+            ^/picdesc.xml
+            ^/pi.php
+            ^/platform-ui/
+            ^/plugin/ueditor/net/controller.ashx?action=catchimage
+            ^/plugs/ueditor/net/controller.ashx?action=catchimage
+            ^/plycomconf/
+            ^/pma2/index.php
+            ^/pma/print.css
+            ^/polycom/
+            ^/portable-phpmyadmin
+            ^/portal/
+            ^/portal/redlion
+            ^/portal/wp-includes/wlwmanifest.xml
+            ^/profile/register/
+            ^/properties/configuration.php?tab=status
+            ^/properties/description.dhtml
+            ^/prov/
+            ^/provision/
+            ^/provisioning/
+            ^/ptz.htm
+            ^/public/admin/index.htm
+            ^/public/.env
+            ^/public/images/skype/skype_1.gif/1.php
+            ^/rest-service/reviews-v/versioninfo
+            ^/qip
+            ^/qsoap.qap
+            ^/qwe/qwe/index.html
+            ^/rails_info/properties
+            ^/rdweb/login/login.html
+            ^/recoveryconsole/
+            ^/reguser.php
+            ^/remote/login
+            ^/.remote-sync.json
+            ^/reporter/client.jsp
+            ^/reportserver
+            ^/requested.html
+            ^/res/license.txt
+            ^/rev/50btc.php
+            ^/rev/no.php
+            ^/rev/people.php
+            ^/rev/pi.php
+            ^/+rnum+
+            ^/robots.php
+            ^/root.php
+            ^/roundcube
+            ^/rsaarcher/default.asp
+            ^/rsaarcher/default.aspx
+            ^/ruei/index.php
+            ^/rxr.php
+            ^/rxr.php?rxr
+            ^/sametime/buildinfo.txt
+            ^/sapmc/sapmc.html
+            ^/sbb.cgi
+            ^/sbnqoook.asmx
+            ^/scarbook.php
+            ^/scgi-bin/platform.cgi
+            ^/scmadmin/
+            ^/scripts
+            ^/scripts/jquery/maticsoft.jquery.min.js
+            ^/scripts/wwho.dll
+            ^/se/appinfo.xml
+            ^/search/results.stm
+            ^/security.txt
+            ^/se/emc_se.swf
+            ^/self_upgrade.html
+            ^/sellers.json
+            ^/seo-joy.cgi
+            ^/server-info
+            ^/server/php/
+            ^/server-status
+            ^/servlet/com.newatlanta.servletexec.jsp
+            ^/servlet?m=mod_listener&p=login&q=loginform&jumpto=status
+            ^/wordpress/xmlrpc.php
+            ^/servlet/snoop/
+            ^/servlet/snoopservlet/
+            ^/sess-bin/login_session.cgi
+            ^/seter.php
+            ^/setup.cgi
+            ^/setup.cgi?next_file=netgear.cfg&todo=syscmd&cmd=busybox&curpath=/&currentsetting.htm=1
+            ^/sftp-config.json
+            ^/sgdadmin/faces/jsp/version.jsp
+            ^/shared/userlogin.php
+            ^/shell?busybox
+            ^/shell?cd+
+            ^/shell?cd+/tmp
+            ^/shell.php
+            ^/templates/beez5/error.php
+            ^/system.xml
+            ^/smtime.nsf
+            ^/sites/all/libraries/elfinder/connectors/php/connector.php
+            ^/shop/.env
+            ^/shop/admin/
+            ^/shop/admin/index.php
+            ^/shop/administrator
+            ^/shop/admin/login
+            ^/shop/admin/login.asp
+            ^/shop/admin.php
+            ^/shop/admin/signin.aspx
+            ^/shop/amember/admin
+            ^/shop/backend
+            ^/shop/_cpanel
+            ^/shop/index.php?s=admin
+            ^/shop/login.php
+            ^/shop/merchant2/admin.mvc
+            ^/shop/sitecore/login
+            ^/shop/wp-includes/wlwmanifest.xml
+            ^/shop/xtadmin
+            ^/shop/zencart/admin/admin.php
+            ^/shop/zencart/admin/login.php
+            ^/silverstream
+            ^/sip.cfg
+            ^/sitecore
+            ^/sitecore/login
+            ^/sitecorx/login
+            ^/sites/all/libraries/mailchimp/vendor/phpunit/phpunit/build.xml
+            ^/sites/.env
+            ^/sito/wp-includes/wlwmanifest.xml
+            ^/smadmr.nsf
+            ^/smb_scheduler/cdr.htm
+            ^/smconf.nsf
+            ^/smency.nsf
+            ^/smftypes.nsf
+            ^/smhelp.nsf
+            ^/smmsg.nsf
+            ^/smquar.nsf
+            ^/smsmvlog.nsf
+            ^/snmx-cgi/fxm.exe
+            ^/snoop/
+            ^/snoopservlet/
+            ^/soapcaller
+            ^/soap:envelope
+            ^soap:envelope
+            ^/something/maybe/ping
+            ^/spa$ma.cfg
+            ^/spotfire/about.jsp
+            ^/spywall/login.php
+            ^/spywall/timeconfig.php
+            ^/sqbcdaysmmxf
+            ^/struts/webconsole.html
+            ^/store/admin/index.php
+            ^/sql/
+            ^/ssp/
+            ^/stager
+            ^stager
+            ^/stager64
+            ^stager64
+            ^/staging/wp-includes/wlwmanifest.xml
+            ^/start.js
+            ^/status.php
+            ^/status.xsl
+            ^/stcenter.nsf
+            ^/store/
+            ^/store/admin
+            ^/store/admin/login
+            ^/store/admin/login.asp
+            ^/store/admin.php
+            ^/store/admin/signin.aspx
+            ^/store/amember/admin
+            ^/store/backend
+            ^/store/login.php
+            ^/store/wp-includes/wlwmanifest.xml
+            ^/stream/
+            ^/stronghold-info
+            ^/stronghold-status
+            ^/styles.php
+            ^/subscribe.phpsubscribe.php
+            ^/.svn/entries
+            ^/.svn/wc.db
+            ^/sws/data/sws_data.js
+            ^/swvm/consolecontainer.jsp
+            ^/syslog.htm
+            ^/system/.env
+            ^/systeminfo
+            ^/system/login
+            ^/system.php
+            ^/t4.php
+            ^/tbl_add.php?action=
+            ^/teamportal/showstudy/show/12.json
+            ^/teamportal/trace
+            ^/telerik.web.ui.webresource.axd?type=rau
+            ^/temp/
+            ^/templates/atomic/error.php
+            ^/templates/atomic/index.php
+            ^/templates/beez_20/error.php
+            ^/templates/beez_20/index.php
+            ^/templates/beez3/error.php
+            ^/templates/beez3/index.php
+            ^/templates/beez5/index.php
+            ^/templates/beez/index.php
+            ^/templates/ja_purity/index.php
+            ^/templates/protostar/error.php
+            ^/templates/protostar/index.php
+            ^/templates/rhuk_milkyway/index.php
+            ^/templates/system/error.php
+            ^/templates/system/index.php
+            ^/temporary_listen_addresses/smsservice
+            ^/test/.env
+            ^/testing
+            ^/test/wp-admin/
+            ^/test/wp-includes/wlwmanifest.xml
+            ^/ui/
+            ^/ui/faces/login.xhtml
+            ^/tmp/license.txt
+            ^/test/wp-login.php
+            ^/test wuz here
+            ^:test wuz here
+            ^/tftboot/
+            ^/tftpboot/
+            ^/tftpphone/
+            ^/tftproot/
+            ^/theme1.php
+            ^/theme.php
+            ^/this_page_should_not_exist.htm
+            ^/this_server/all_settings.shtml
+            ^/tightvnc-jviewer.jar
+            ^/tmp/
+            ^/tmpfs/snap.jpg
+            ^/tmp/vuln.php
+            ^/tmui/
+            ^/tmunblock.cgi
+            ^/tools/phpmyadmin/index.ph
+            ^/tp/public/index.php
+            ^/trace.axd
+            ^/trc
+            ^/triton-help/en/first.htm
+            ^/tsp/
+            ^/typo3
+            ^/uddi/default.aspx
+            ^/uddipublic/default.aspx
+            ^/ueditor/net/controller.ashx
+            ^/ueditor/net/controller.ashx?action=catchimage
+            ^/ui/login/
+            ^/upel.php
+            ^/upload.php
+            ^/up.php
+            ^/ups.php
+            ^/usage/
+            ^/usercenter/css/admin/bgimg/admin_all_bg.png
+            ^/user/index.php
+            ^/userportal/webpages/myaccount/login.jsp
+            ^/user/register/
+            ^/user_settings.cfg
+            ^/user/soapcaller.bs
+            ^/usr/lib/cgi-bin/kerbynet
+            ^/usr/lib/cgi-bin/test-cgi
+            ^/v1/
+            ^/v1/agent/self
+            ^/v1/wp-includes/wlwmanifest.xml
+            ^/v2/
+            ^/v2/wp-includes/wlwmanifest.xml
+            ^/var/resource_config.json
+            ^/vb5/js/ajax.js
+            ^/vbforum/js/ajax.js
+            ^/vbulletin/js/ajax.js
+            ^/vendor/.env
+            ^/vendor/phpunit/phpunit/build.xml
+            ^/vendor/phpunit/phpunit/license
+            ^/vendor/phpunit/phpunit/src/util/php/xsamxadoo_bot.php
+            ^/vsyfgtyt
+            ^/version
+            ^/view/hsrindex.shtml
+            ^/view.html
+            ^/view/view.shtml
+            ^/vncviewer.jar
+            ^/vpns/cfg/smb.conf
+            ^/vpn/../vpns/
+            ^/vpn/../vpns/cfg/smb.conf
+            ^/.vscode/ftp-sync.json
+            ^/.vscode/sftp.json
+            ^/vsmc.html
+            ^/_vti_bin/fpcount.exe
+            ^/_vti_bin/shtml.dll/_vti_rpc
+            ^/w00tw00t
+            ^/w00tw00t.at.isc.sans.dfind
+            ^/w0rm.html.php
+            ^/wallet.dat
+            ^/wanipcn.xml
+            ^/wavemaster.internal
+            ^/wcd/system.xml
+            ^/web/
+            ^/web2/
+            ^/webalizer/
+            ^/webapps/login/index.html
+            ^/webbuilder/script/locale/wb-lang-zh_cn.js
+            ^/webui/apps/sdcss
+            ^/webcam/webcam.html
+            ^/web.config
+            ^/web.config.txt
+            ^/web-console/serverinfo.jsp
+            ^/webconsole/webpages/login.jsp
+            ^/webct/about.jsp
+            ^/webdb
+            ^/webfig/
+            ^/webhost
+            ^/./web-inf/
+            ^/web/phpmyadmin/index.php
+            ^/website/
+            ^/website/wp-includes/wlwmanifest.xml
+            ^/website/wp-login.php
+            ^/web/wp-includes/wlwmanifest.xml
+            ^/.well-known/autoconfig/mail/config-v1.1.xml
+            ^/wls_utc/
+            ^/wls-wsat/coordinatorporttype
+            ^/woorewards
+            ^/wordpress/
+            ^/wordpress2/
+            ^/wordpress/license.txt
+            ^/wordpress/readme.txt
+            ^/wordpress/wp-admin/
+            ^/wordpress/wp-admin/install.php
+            ^/wordpress/wp-includes/wlwmanifest.xml
+            ^/wos.php
+            ^/wp/
+            ^/wp-1ogin_bak.php?eanver=phpcode
+            ^/wp1/wp-login.php
+            ^/wp2/
+            ^/wp2/wp-includes/wlwmanifest.xml
+            ^/wp2/xmlrpc.php
+            ^/wp-404.php
+            ^/wp-acess.php
+            ^/wp-action.php
+            ^/wp-admin/admin-ajax.php?action=duplicator_download&file=../wp-config.php
+            ^/wp-admine.php
+            ^/wp-admin/install.php
+            ^/wp-admin/network/wp-footer.php
+            ^/wp-admin/shapes.php
+            ^/wp-adm.php
+            ^/wp-anyconf.php
+            ^/wp-back.php
+            ^/wp-blog-mail.php
+            ^/wp-blog.php
+            ^/wp-config.bak
+            ^/wp-config.old
+            ^../wp-config.php
+            ^/wp-config.php~
+            ^/wp-config.php.bak
+            ^/wp-config.php.dist
+            ^/wp-config.php.inc
+            ^/wp-config.php.orig
+            ^/wp-config.php.original
+            ^/wp-config.php.save
+            ^/wp-config.php.swp
+            ^/wp-config.txt
+            ^/wp-conf.php
+            ^/wp-content/plugins/addfreestats/
+            ^/wp-content/plugins/add-linked-images-to-gallery-v01/
+            ^/wp-content/plugins/addon-library/
+            ^/wp-content/plugins/add-tags-and-category-to-page/
+            ^/wp-content/plugins/add-to-any/
+            ^/wp-content/plugins/add-to-any-subscribe/
+            ^/wp-content/plugins/add-widget-after-content/
+            ^/wp-content/plugins/adkingpro/
+            ^/wp-content/plugins/admin-bar-dashboard-control/
+            ^/wp-content/plugins/admin-category-filter/
+            ^/wp-content/plugins/admin-collapse-subpages/
+            ^/wp-content/plugins/admin-in-english/
+            ^/wp-content/plugins/admin-page-spider/
+            ^/wp-content/plugins/admin-trim-interface/
+            ^/wp-content/plugins/adsense-in-post-ads-by-oizuled/
+            ^/wp-content/plugins/adsense-plugin/
+            ^/wp-content/plugins/advanced-cron-manager/
+            ^/wp-content/plugins/advanced-css-editor/
+            ^/wp-content/plugins/advanced-custom-fields-location-field-add-on/
+            ^/wp-content/plugins/advanced-permalinks/
+            ^/wp-content/plugins/advanced-post-list/
+            ^/wp-content/plugins/advanced-product-labels-for-woocommerce/
+            ^/wp-content/plugins/advanced-reporting-for-woocommerce/
+            ^/wp-content/plugins/advanced-text-widget/
+            ^/wp-content/plugins/advanced-tinymce-configuration/
+            ^/wp-content/plugins/adwords-conversion-tracking-code/
+            ^/wp-content/plugins/aesop-story-engine/
+            ^/wp-content/plugins/affiliates/
+            ^/wp-content/plugins/age-gate/
+            ^/wp-content/plugins/agile-crm-lead-management/
+            ^/wp-content/plugins/agile-store-locator/
+            ^/wp-content/plugins/ai-responsive-gallery-album/
+            ^/wp-content/plugins/ajax-adsense/
+            ^/wp-content/plugins/another-wordpress-classifieds-plugin/awpcp.po
+            ^/wp-content/plugins/apikey
+            ^/wp-content/plugins/background-image-cropper/content-post.php
+            ^/wp-content/plugins/baggage-freight/readme.txt
+            ^/wp-content/plugins/cimy-user-extra-fields/readme_official.txt
+            ^/wp-content/plugins/complete-gallery-manager/frames/upload-images.php
+            ^/wp-content/plugins/contabileads/integracoes/mautic/api-library/vendor/phpunit/phpunit/build.xml
+            ^/wp-content/plugins/contus-hd-flv-player/uploadvideo.php
+            ^/wp-content/plugins/delucks-seo/readme.txt
+            ^/wp-content/plugins/downloads-manager/img/unlock.gif
+            ^/wp-content/plugins/dzs-videogallery/class_parts/vendor/phpunit/phpunit/build
+            ^/wp-content/plugins/font-uploader/fontfunctions/fu_script.js
+            ^/wp-content/plugins/mm-plugin/inc/vendors/vendor/phpunit/phpunit/build.xml
+            ^/wp-content/plugins/page-flip-image-gallery/upload.php
+            ^/wp-content/plugins/photo-gallery/filemanager/uploadhandler.php
+            ^/wp-content/plugins/ppus/up.php
+            ^/wp-content/plugins/realia/libraries/paypal-php-sdk/vendor/phpunit/phpunit/build.xml
+            ^/wp-content/plugins/tevolution/tmplconnector/monetize/templatic-custom_fields/css/jquery.lightbox.css
+            ^/wp-content/plugins/html404/index.html
+            ^/wp-content/plugins/ioptimization
+            ^/wp-content/plugins/ioptimization/ioptimize.php?rchk
+            ^/wp-content/plugins/jekyll-exporter/vendor/phpunit/phpunit/build.xml
+            ^/wp-content/plugins/jquery-html5-file-upload/readme.txt
+            ^/wp-content/plugins/mac-dock-gallery/readme.txt
+            ^/wp-content/plugins/magic-fields/mf_constant.php
+            ^/wp-content/plugins/mailcwp/mailcwp-upload.php
+            ^/wp-content/plugins/mm-forms-community/includes/ajaxfileupload.php
+            ^/wsi.php
+            ^/wso.php
+            ^/ws.php
+            ^/wp-content/uploads/wpcf7_uploads/
+            ^/wp-content/plugins/theme-configurator/mini.php
+            ^/wp-content/plugins/tourmaster/include/authorize/vendor/phpunit/phpunit/build.xml
+            ^/wp-content/plugins/ubh/index.php
+            ^/wp-content/plugins/upspy/index.php
+            ^/wp-content/plugins/vwcleanerplugin/bump.php?cache
+            ^/wp-content/plugins/widget-logic/mini.php
+            ^/wp-content/plugins/wp-file-manager
+            ^/wp-content/plugins/wp-file-manager/lib/php/connector.minimal.php
+            ^/wp-content/plugins/wp-file-manager/readme.txt
+            ^/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/build.xml
+            ^/wp-content/plugins/xichang/x.php?xi
+            ^/wp-content/vuln.php
+            ^/wp-content/wp-1ogin_bak.php
+            ^/wp-includes/css/modules.php
+            ^/wp-info.php
+            ^/wp-json/wp_live_chat_support/v1/get_status
+            ^/wp-json/wp/v2/users
+            ^/wp-links.php
+            ^/wp-login.php?action=register
+            ^/wp-mains.php
+            ^/wp-on.php
+            ^/wp-test/
+            ^/wptest/
+            ^/wp/wp-admin/
+            ^/wp/wp-includes/wlwmanifest.xml
+            ^/wp_wrong_da
+            ^/wsusadmin/errors/browsersettings.aspx
+            ^/ws_utc/login.do
+            ^/wwos.php
+            ^/www/license.txt
+            ^/www/phpmyadmin/index.php
+            ^/www/wp-includes/wlwmanifest.xml
+            ^\x00cookie:
+            ^\x22jdatabasedrivermysqli
+            ^\x22jsimplepiefactory
+            ^\x22simplepie
+            ^\x5c0disconnecthandlers
+            ^/xampp
+            ^/xampp/index.php
+            ^/xmlr
+            ^/xxx.php
+            ^/y000000000000.cfg
+            ^/wp-content/plugins/theme-configurator/mini.php
+            ^/wp-content/plugins/tourmaster/include/authorize/vendor/phpunit/phpunit/build.xml
+            ^/wp-content/plugins/ubh/index.php
+            ^/wp-content/plugins/upspy/index.php
+            ^/wp-content/plugins/vwcleanerplugin/bump.php?cache
+            ^/wp-content/plugins/widget-logic/mini.php
+            ^/wp-content/plugins/wp-file-manager
+            ^/wp-content/plugins/wp-file-manager/lib/php/connector.minimal.php
+            ^/wp-content/plugins/wp-file-manager/readme.txt
+            ^/wp-content/plugins/wp-rocket/vendor/phpunit/phpunit/build.xml
+            ^/wp-content/plugins/xichang/x.php?xi
+            ^/wp-content/themes/satoshi/upload-file.php
+            ^/y000000000004.cfg
+            ^/yabb.cgi
+            ^/yabb.pl
+            ^/yapgb.php
+            ^/yapgb.php/index.php
+            ^/yealink/
+            ^/yybbs.cgi
+            ^/zencart/admin/admin.php
+            ^/zencart/admin/login.php
+            ^/.bzr/branch  format
+            ^/.bzr/repository/format
+            ^/chassis/config/generalchassisconfig.html
+            ^/chat/common/server/php/file.php
+            ^/ckeditor/kcfinder/browse.php
+            ^/client/
+            ^/clientaccesspolicy.xml
+            ^/clientpage.php
+            ^/_cms/
+            ^/cms/
+            ^/cms/wp-includes/wlwmanifest.xml
+            ^/.cobalt
+            ^/comments.phptrackback
+            ^/common/about.php
+            ^/com/novell/webaccess/webaccessuninstall.ini
+            ^/components/com_b2jcontact/izoc.php
+            ^/component/users/
+            ^/cgi-bin/config.exp
+            ^/cgi-bin/mainfunction.cg
+            ^/cgi-bin/printenv
+            ^/cgi-bin/test-cgi
+            ^/cgi-bin/weblogin.cgi
+            ^/cgi/execute
+            ^/cgi/guestbook?page=1
+            ^/cgi-mod/index.cgi
+            ^/cgi-bin/ctrldirect.cgi
+            ^/cgi-bin/filescan
+            ^/cgi-bin/file_transfer.cgi
+            ^/cgi-bin/guestimage.html
+            ^/cgi-bin/index.cgi
+            ^/cgi-bin/kerbynet?Action=Render&Object=StartSession
+            ^/cgi-bin/kerbynet?action=x509view
+            ^/cgi-bin/kerbynet?section=
+            ^/cgi-bin/login.cgi
+            ^/c/
+            ^/cachepages/hiking-safety.php
+            ^/card_scan_decoder.php
+            ^/cas/login
+            ^/catalog/adminhtml_categor
+            ^/caucho-status
+            ^/cfg/000000000000.cfg
+            ^/cfide/administrator/
+            ^/cfide/administrator/index.cfm
+            ^/cfide/administrator/settings/version.cfm
+            ^/cgi-bin/camctrl.cgi
+            ^/bbs.php?routestring=ajax/render/widget_php
+            ^/bd.php
+            ^/blogadmin/wp-admin/ 
+            ^/blogbackup/
+            ^/boaform/admin/formlogin?username=
+            ^/boaform/admin/formlogin?username=adminisp&psd=adminisp
+            ^/boaform/admin/formlogin?username=admin&psd=admin
+            ^/boaform/admin/formlogin?username=ec8&psd=ec8
+            ^/boaform/admin/formping
+            ^/book.php
+            ^/brightmail/viewlogin.do
+            ^/builtin/index.html
+            ^/buysticker. php
+            ^/buysticker.php
+            ^/blog/.env
+            ^/blogg/
+            ^/blogs/wp-includes/wlwmanifest.xml
+            ^/blog/wp-includes/wlwmanifest.xml
+            ^/blog/wp-json/
+            ^/blog/wp-login.php
+            ^/blog/xmlrpc.php
+            ^/boaform/admin/forming
+            ^/boaform/admin/formlogin
+            ^/bea_wls_deployment_internal
+            ^/beta/
+            ^/beta/wp-includes/wlwmanifest.xml
+            ^/.bitcoin/
+            ^/bitcoin.dat
+            ^/bladeacss.php
+            ^/bla.php
+            ^/blazeds/messagebroker/http
+            ^/blazeds/messagebroker/httpsecure
+            ^/blog/
+            ^/blog2/
+            ^/assets/admin/ckeditor/kcfinder/browse.php
+            ^/assets/ckeditor/kcfinder/browse.php
+            ^/assets/images/accesson.php
+            ^/assets/js/kcfinder/browse.php
+            ^/assets/kcfinder/browse.php
+            ^/assets/ueditor/net/controller.ashx?action=catchimage
+            ^/asterisk/
+            ^/ata/
+            ^/authenticate/login
+            ^/authentication/login/
+            ^/auth/login
+            ^/aztgear.php
+            ^/back/
+            ^/backend/
+            ^/back/license.txt
+            ^/backup/
+            ^/backup.rar
+            ^/backup.sql
+            ^/backup.tar.gz
+            ^/backup.tgz
+            ^/backup/wp-admin/
+            ^/backup/wp-includes/wlwmanifest.xml
+            ^/backup/wp-login.php
+            ^/backup.zip
+            ^/bak/index.php
+            ^/baselining/version
+            ^/base.php
+            ^/bavbulysuhlw
+            ^/bbs.cgi
+            ^/bbs/index.php
+            ^/bbs.php
+            ^/autodiscover/autodiscover.xml
+            ^/autopass/login_input
+            ^/av-centerd
+            ^/axis/directdownload.js
+            ^/98820b975faf1aa0b4400370ab1d3a
+            ^/api/.env
+            ^/api.php
+            ^/api.php?key=1
+            ^/app-ads.txt
+            ^/app/.bzr/branch-format
+            ^/app/.bzr/repository/format
+            ^/app/.git/config
+            ^/app/idxasp.html
+            ^/app/js/source/wcmlib/wcmconstants.js
+            ^/appliance/
+            ^/apps/guestbook
+            ^/apps/zxtm/login.cgi
+            ^/app/tpl/fanwe_1/js/
+            ^/app/ui/login.jsp
+            ^/app.zip
+            ^/arx/license.txt
+            ^/aska.cgi
+            ^/a2billing/
+            ^/admin/
+            ^/admin2aa51c95/login.php
+            ^/admin65193f2d/login.php
+            ^/admin.back
+            ^/adminc8a0b48b/login.php
+            ^/admin/ckeditor/kcfinder/browse.php
+            ^/admin/common/helplinks.xml
+            ^/admin/config.php/admincp/login.php
+            ^/admin/.env
+            ^/adminer-4.0.0.php
+            ^/adminer.php
+            ^/admin/ewebeditor/ueditor/net/controller.ashx?action=catchimage
+            ^/install/
+            ^/administrator/
+            ^/administrator/help/en-gb/toc.json
+            ^/administrator/templates/bluestork/error.php
+            ^/administrator/templates/bluestork/index.php
+            ^/administrator
+            ^/a2billing/admin/public/index.php
+            ^/a2billing/admin/public/pp_error.php?c=accessdenied
+            ^/a2billing/customer/templates/default/footer.tpl
+            ^/aastra.cfg
+            ^/about.jsp
+            ^/about.php
+            ^/aboutprinter.html
+            ^/accesson.php
+            ^/active.log
+            ^/administrator/index\.php.*500
+            ^/:8880/
+            ^/addons/theme/stv1/_static/image/favicon\.ico
+            ^/addons/theme/stv1/_static/ts2/layout\.css
+            ^/addons/theme/stv2/_static/ts2/layout\.css
+            ^/Admin/Common/HelpLinks\.xml
+            ^/admin-console
+            ^/admin/inc/xml\.xslt
+            ^/administrator/components/com_xcloner-backupandrestore/index2\.php
+            ^/administrator/index\.php
+            ^/administrator/manifests/files/joomla\.xml
+            ^/admin/mysql2/index\.php
+            ^/admin/mysql/index\.php
+            ^/admin/phpMyAdmin/index\.php
+            ^/admin/pma/index\.php
+            ^/admin/PMA/index\.php
+            ^/admin/SouthidcEditor/ButtonImage/standard/componentmenu\.gif
+            ^/admin/SouthidcEditor/Dialog/dialog\.js
+            ^/admin/SouthidcEditor/ewebeditor\.asp
+            ^/API/DW/Dwplugin/SystemLabel/SiteConfig\.htm
+            ^/API/DW/Dwplugin/TemplateManage/login_site\.htm
+            ^/API/DW/Dwplugin/TemplateManage/manage_site\.htm
+            ^/API/DW/Dwplugin/TemplateManage/save_template\.htm
+            ^/API/DW/Dwplugin/ThirdPartyTags/SiteFactory\.xml
+            ^/app/home/skins/default/style\.css
+            ^/app/js/source/wcmlib/WCMConstants\.js
+            ^/apple-app-site-association
+            ^/app/Tpl/fanwe_1/js/
+            ^/_asterisk/
+            ^/bencandy\.php
+            ^/blog/administrator/index\.php
+            ^/cgi-bin/php
+            ^/cgi-bin/php5
+            ^/cgi/common\.cgi
+            ^/CGI/Execute
+            ^/check\.proxyradar\.com/azenv\.php
+            ^/ckeditor/ckfinder/ckfinder\.html
+            ^/ckeditor/ckfinder/install\.txt
+            ^/ckfinder/ckfinder\.html
+            ^/ckfinder/install\.txt
+            ^/ckupload\.php
+            ^/claroline/phpMyAdmin/index\.php
+            ^/clases\.gone\.php
+            ^/cms/administrator
+            ^/command\.php
+            ^/components/com_adsmanager/js/fullnoconflict\.js
+            ^/components/com_b2jcontact/css/b2jcontact\.css
+            ^/components/com_b2jcontact/router\.php
+            ^/components/com_foxcontact/js/jtext\.js
+            ^/components/com_sexycontactform/assets/js/index\.html
+            ^/console/auth/reg_newuser\.jsp
+            ^/console/include/not_login\.htm
+            ^/console/js/CTRSRequestParam\.js
+            ^/console/js/CWCMDialogHead\.js
+            ^/currentsetting\.htm
+            ^/CuteSoft_Client/CuteEditor/Help/default\.htm
+            ^/CuteSoft_Client/CuteEditor/ImageEditor/listfiles\.aspx
+            ^/CuteSoft_Client/CuteEditor/Images/log\.gif
+            ^/data/admin/ver\.txt
+            ^/datacenter/downloadApp/showDownload\.do
+            ^/db/
+            ^/dbadmin/
+            ^/dbadmin/index\.php
+            ^/db/index\.php
+            ^/deptWebsiteAction\.do
+            ^/eams/static/scripts/grade/course/input\.js
+            ^/editor/js/fckeditorcode_ie\.js
+            ^/examples/file-manager\.html
+            ^/getcfg\.php
+            ^/get_password\.php
+            ^/\.git/info/
+            ^/Hello\.World
+            ^/hndUnblock\.cgi
+            ^/images/login9/login_33\.jpg
+            ^/include/dialog/config\.php
+            ^/include/install_ocx\.aspx
+            ^/index\.action
+            ^/ip_js\.php
+            ^/issmall/
+            ^/jenkins/script
+            ^/jm-ajax/upload_file/
+            ^/jmx-console
+            ^/js/tools\.js
+            ^/libraries/sfn\.php
+            ^login\.destroy\.session
+            ^/login/Jeecms\.do
+            ^/logo_img\.php
+            ^/maintlogin\.jsp
+            ^/manager/html
+            ^/manager/status
+            ^/master/login\.aspx
+            ^/media/com_hikashop/js/hikashop\.js
+            ^/modules/attributewizardpro/config\.xml
+            ^/modules/columnadverts/config\.xml
+            ^/modules/fieldvmegamenu/config\.xml
+            ^/modules/homepageadvertise2/config\.xml
+            ^/modules/homepageadvertise/config\.xml
+            ^/modules/mod_simplefileuploadv1\.3/elements/udd\.php
+            ^/modules/pk_flexmenu/config\.xml
+            ^/modules/pk_vertflexmenu/config\.xml
+            ^/modules/wdoptionpanel/config\.xml
+            ^/msd
+            ^/msd1\.24\.4
+            ^/msd1\.24stable
+            ^mstshash=NCRACK_USER
+            ^/muieblackcat
+            ^/myadmin2/index\.php
+            ^/myadmin/index\.php
+            ^/myadmin/scripts/setup\.php
+            ^/MyAdmin/scripts/setup\.php
+            ^/mysql-admin/index\.php
+            ^/mysqladmin/index\.php
+            ^/mysqldumper
+            ^/mySqlDumper
+            ^/MySQLDumper
+            ^/phpadmin/index\.php
+            ^/phpma/index\.php
+            ^/phpMyadmin_bak/index\.php
+            ^/phpMyAdmin/index\.php
+            ^/phpMyAdmin/phpMyAdmin/index\.php
+            ^/phpMyAdmin/scripts/setup\.php
+            ^/plugins/anchor/anchor\.js
+            ^/plugins/filemanager/filemanager/js
+            ^/plus/download\.php
+            ^/plus/heightsearch\.php
+            ^/plus/rssmap\.html
+            ^/plus/sitemap\.html
+            ^/pma/
+            ^/PMA/
+            ^/PMA2/index\.php
+            ^/pma/index\.php
+            ^/PMA/index\.php
+            ^/pmamy2/index\.php
+            ^/pmamy/index\.php
+            ^/pma-old/index\.php
+            ^/pma/scripts/setup\.php
+            ^/pmd/index\.php
+            ^/privacy\.txt
+            ^/resources/style/images/login/btn\.png
+            ^/Scripts/jquery/maticsoft\.jquery\.min\.js
+            ^/script/valid_formdata\.js
+            ^/siteserver/login\.aspx
+            ^/siteserver/upgrade/default\.aspx
+            ^soap:Envelope
+            ^/stalker_portal/server/adm/tv-channels/iptv-list-json
+            ^/stalker_portal/server/adm/users/users-list-json
+            ^/stssys\.htm
+            ^/sys\.cache\.php
+            ^/system/assets/jquery/jquery-2\.x\.min\.js
+            ^/template/1/bluewise/_files/jspxcms\.css
+            ^/templates/jsn_glass_pro/ext/hikashop/jsn_ext_hikashop\.css
+            ^/test_404_page/
+            ^/test_for_404/
+            ^Test Wuz Here
+            ^/tmUnblock\.cgi
+            ^/tools/phpMyAdmin/index\.ph
+            ^/uc_server/control/admin/db\.php
+            ^/upload/bank-icons/
+            ^/UserCenter/css/admin/bgimg/admin_all_bg\.png
+            ^/\.user\.ini
+            ^\.bitcoin
+            ^wallet\.dat
+            ^bitcoin\.dat
+            ^/magento2/admin
+            ^/user/register?element_parents=account
+            ^/user/themes/antimatter/js/antimatter\.js
+            ^/user/themes/antimatter/js/modernizr\.custom\.71422\.js
+            ^/user/themes/antimatter/js/slidebars\.min\.js
+            ^/w00tw00t
+            ^/webbuilder/script/locale/wb-lang-zh_CN\.js
+            ^/web-console
+            ^/webdav
+            ^/web/phpMyAdmin/index\.php
+            ^/whir_system/login\.aspx
+            ^/whir_system/module/security/login\.aspx
+            ^/wls-wsat/CoordinatorPortType
+            ^/wpbase/url\.php
+            ^/wp-includes/wlwmanifest\.xml
+            ^/wp-login\.php
+            ^/www/phpMyAdmin/index\.php
+            ^\x00Cookie:
+            ^\x22cache_name_function
+            ^\x22JDatabaseDriverMysqli
+            ^\x22JSimplepieFactory
+            ^\x22sanitize
+            ^\x22SimplePie
+            ^\x5C0disconnectHandlers
+            ^\.\./wp-config.php
+            ^/admin/assets/js/views/login.js
+            ^/000000000000.cfg
+            ^/098.php
+            ^/0.php
+            ^/123.php
+            ^/1/license.txt
+            ^/1.php
+            ^/1/wp-includes/wlwmanifest.xml
+            ^/2018/wp-includes/wlwmanifest.xml
+            ^/2019/wp-includes/wlwmanifest.xml
+            ^/2019/wp-login.php
+            ^/2020/wp-login.php
+            ^/2.php
+            ^/2/wp-includes/wlwmanifest.xml
+            ^/50btc.php
+            ^/65193f2d/admin.php
+            ^/stalker_portal/server/tools/auth_simple.php
+            ^/actuator/health
+            ^/boaform/admin/formLogin?username=adminisp&psd=adminisp
+            ^/ecp/Current/exporttool/microsoft.exchange.ediscovery.exporttool.application
+            ^/HNAP1/
+            ^/cgi-bin/.%%2e/.%%2e/.%%2e/.%%2e/.%%2e/.%%2e/.%%2e/.%%2e/.%%2e/.%%2e/bin/sh
+            ^/cgi-bin/%%%%32%%65%%%%32%%65/%%%%32%%65%%%%32%%65/%%%%32%%65%%%%32%%65/%%%%32%%65%%%%32%%65/%%%%32%%65%%%%32%%65/%%%%32%%65%%%%32%%65/%%%%32%%65%%%%32%%65/bin/sh
+            ^/hello.world?%%ADd+allow_url_include%%3d1+%%ADd+auto_prepend_file%%3dphp://input
+            ^MGLNDD_24.135.28.73_80\n
 ignoreregex =


### PR DESCRIPTION
As suggested in https://github.com/fail2ban/fail2ban/issues/2762#issuecomment-647584100 , this filter config style is parsed much faster by fail2ban
```diff
rosenstein@server:~$ sudo fail2ban-regex /var/log/apache2/access.log-20250402 /etc/fail2ban/filter.d/webexploits.conf
- old style
Running tests
=============

Use   failregex filter file : webexploits, basedir: /etc/fail2ban
Use         log file : /var/log/apache2/access.log-20250402
Use         encoding : UTF-8


Results
=======

-Failregex: 717 total
|-  #) [# of hits] regular expression
|   1) [10] ^<HOST> -.*(GET|POST|HEAD).*(/\.git/config)
|   4) [1] ^<HOST> -.*(GET|POST|HEAD).*(/?XDEBUG_SESSION_START=phpstorm)
|   7) [52] ^<HOST> -.*(GET|POST|HEAD).*(/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php)
|  13) [52] ^<HOST> -.*(GET|POST|HEAD).*(/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php)
|  14) [1] ^<HOST> -.*(GET|POST|HEAD).*(/hudson)
|  15) [2] ^<HOST> -.*(GET|POST|HEAD).*(/wp-config.php)
|  76) [4] ^<HOST> -.*(GET|POST|HEAD).*(/demo/)
|  85) [38] ^<HOST> -.*(GET|POST|HEAD).*(/dev/)
|  86) [2] ^<HOST> -.*(GET|POST|HEAD).*(/develop/)
|  95) [2] ^<HOST> -.*(GET|POST|HEAD).*(/dns-query)
|  111) [281] ^<HOST> -.*(GET|POST|HEAD).*(/.env)
|  140) [10] ^<HOST> -.*(GET|POST|HEAD).*(/.git/config)
|  157) [5] ^<HOST> -.*(GET|POST|HEAD).*(/hello.world)
|  168) [2] ^<HOST> -.*(GET|POST|HEAD).*(/home/)
|  210) [3] ^<HOST> -.*(GET|POST|HEAD).*(/info.php)
|  231) [1] ^<HOST> -.*(GET|POST|HEAD).*(/kcfinder/browse.php)
|  234) [4] ^<HOST> -.*(GET|POST|HEAD).*(/laravel/.env)
|  303) [2] ^<HOST> -.*(GET|POST|HEAD).*(/new/)
|  345) [8] ^<HOST> -.*(GET|POST|HEAD).*(/owa/)
|  346) [4] ^<HOST> -.*(GET|POST|HEAD).*(/owa/auth/logon.aspx)
|  351) [1] ^<HOST> -.*(GET|POST|HEAD).*(/panel/kcfinder/browse.php)
|  356) [4] ^<HOST> -.*(GET|POST|HEAD).*(/password)
|  384) [1] ^<HOST> -.*(GET|POST|HEAD).*(/phpmyadmin3/)
|  400) [2] ^<HOST> -.*(GET|POST|HEAD).*(/portal/)
|  411) [4] ^<HOST> -.*(GET|POST|HEAD).*(/public/.env)
|  421) [1] ^<HOST> -.*(GET|POST|HEAD).*(/remote/login)
|  447) [3] ^<HOST> -.*(GET|POST|HEAD).*(/scripts)
|  455) [2] ^<HOST> -.*(GET|POST|HEAD).*(/sellers.json)
|  480) [2] ^<HOST> -.*(GET|POST|HEAD).*(/shop/.env)
|  561) [2] ^<HOST> -.*(GET|POST|HEAD).*(/system/.env)
|  586) [2] ^<HOST> -.*(GET|POST|HEAD).*(/test/.env)
|  587) [4] ^<HOST> -.*(GET|POST|HEAD).*(/testing)
|  605) [4] ^<HOST> -.*(GET|POST|HEAD).*(/tmp/)
|  635) [4] ^<HOST> -.*(GET|POST|HEAD).*(/v1/)
|  644) [2] ^<HOST> -.*(GET|POST|HEAD).*(/vendor/.env)
|  651) [2] ^<HOST> -.*(GET|POST|HEAD).*(/view.html)
|  669) [43] ^<HOST> -.*(GET|POST|HEAD).*(/web/)
|  676) [8] ^<HOST> -.*(GET|POST|HEAD).*(/web.config)
|  686) [2] ^<HOST> -.*(GET|POST|HEAD).*(/website/)
|  835) [2] ^<HOST> -.*(GET|POST|HEAD).*(/xampp)
|  866) [6] ^<HOST> -.*(GET|POST|HEAD).*(/client/)
|  870) [4] ^<HOST> -.*(GET|POST|HEAD).*(/cms/)
|  930) [4] ^<HOST> -.*(GET|POST|HEAD).*(/beta/)
|  938) [2] ^<HOST> -.*(GET|POST|HEAD).*(/blog/)
|  952) [2] ^<HOST> -.*(GET|POST|HEAD).*(/back/)
|  953) [51] ^<HOST> -.*(GET|POST|HEAD).*(/backend/)
|  955) [5] ^<HOST> -.*(GET|POST|HEAD).*(/backup/)
|  976) [2] ^<HOST> -.*(GET|POST|HEAD).*(/api/.env)
|  977) [2] ^<HOST> -.*(GET|POST|HEAD).*(/api.php)
|  979) [2] ^<HOST> -.*(GET|POST|HEAD).*(/app-ads.txt)
|  994) [49] ^<HOST> -.*(GET|POST|HEAD).*(/admin/)
|  1002) [4] ^<HOST> -.*(GET|POST|HEAD).*(/admin/.env)
|  1007) [2] ^<HOST> -.*(GET|POST|HEAD).*(/administrator/)
|  1011) [2] ^<HOST> -.*(GET|POST|HEAD).*(/administrator)
|  1215) [1] ^<HOST> -.*(GET|POST|HEAD).*(/1.php)
`-

Ignoreregex: 0 total


Lines: 1713 lines, 0 ignored, 564 matched, 1149 missed
-[processed in 29.84 sec]

Missed line(s): too many to print.  Use --print-all-missed to print all 1149 lines

rosenstein@server:~$ sudo fail2ban-regex /var/log/apache2/access.log-20250402 /etc/fail2ban/filter.d/webexploits1.conf
+ new style
Running tests
=============

Use   failregex filter file : webexploits1, basedir: /etc/fail2ban
Use         log file : /var/log/apache2/access.log-20250402
Use         encoding : UTF-8


Results
=======

Prefregex: 1543 total
|  ^(?:\[?(?:(?:::f{4,6}:)?(?P<ip4>(?:\d{1,3}\.){3}\d{1,3})|(?P<ip6>(?:[0-9a-fA-F]{1,4}::?|::){1,7}(?:[0-9a-fA-F]{1,4}|(?<=:):)))\]?|(?P<dns>[\w\-.^_]*\w)) -[^"]*\"(?:GET|POST|HEAD)\s+(?P<content>\S+) HTTP/[^"]+" 40\d\s\d+
`-

+Failregex: 374 total
|-  #) [# of hits] regular expression
|   1) [4] ^(/\.git/config)
|   7) [4] ^/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php
|  13) [4] ^/vendor/phpunit/phpunit/src/Util/PHP/eval-stdin.php
|  14) [1] ^/hudson
|  15) [2] ^/wp-config.php
|  76) [4] ^/demo/
|  85) [36] ^/dev/
|  86) [2] ^/develop/
|  95) [2] ^/dns-query
|  111) [65] ^/.env
|  140) [4] ^/.git/config
|  157) [5] ^/hello.world
|  168) [2] ^/home/
|  210) [2] ^/info.php
|  234) [2] ^/laravel/.env
|  303) [2] ^/new/
|  345) [8] ^/owa/
|  346) [4] ^/owa/auth/logon.aspx
|  351) [1] ^/panel/kcfinder/browse.php
|  356) [3] ^/password
|  400) [2] ^/portal/
|  411) [4] ^/public/.env
|  421) [1] ^/remote/login
|  447) [2] ^/scripts
|  455) [2] ^/sellers.json
|  480) [2] ^/shop/.env
|  561) [2] ^/system/.env
|  586) [2] ^/test/.env
|  587) [2] ^/testing
|  635) [4] ^/v1/
|  644) [2] ^/vendor/.env
|  669) [38] ^/web/
|  676) [8] ^/web.config
|  686) [2] ^/website/
|  835) [2] ^/xampp
|  866) [4] ^/client/
|  870) [4] ^/cms/
|  930) [4] ^/beta/
|  938) [2] ^/blog/
|  952) [2] ^/back/
|  953) [47] ^/backend/
|  955) [5] ^/backup/
|  976) [2] ^/api/.env
|  977) [2] ^/api.php
|  979) [2] ^/app-ads.txt
|  994) [47] ^/admin/
|  1002) [4] ^/admin/.env
|  1007) [2] ^/administrator/
|  1011) [2] ^/administrator
|  1215) [1] ^/1.php
|  1225) [1] ^/stalker_portal/server/tools/auth_simple.php
|  1229) [1] ^/HNAP1/
|  1231) [5] ^/cgi-bin/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/bin/sh
|  1232) [5] ^(/cgi-bin/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/%%32%65%%32%65/bin/sh)
`-

Ignoreregex: 0 total


Lines: 1713 lines, 0 ignored, 348 matched, 1365 missed
+[processed in 1.33 sec]

Missed line(s): too many to print.  Use --print-all-missed to print all 1365 lines
```
Also some, if not all, lines in log are matched multiple times with the old config.
Bash script in this repo also has to be updated, as it will output old style webexploits.conf